### PR TITLE
Expose fuel capacity for overlays

### DIFF
--- a/backend/Models/TelemetryModel.cs
+++ b/backend/Models/TelemetryModel.cs
@@ -197,6 +197,7 @@ namespace SuperBackendNR85IA.Models
         public float FuelUsePerHour { get; set; }
         public float FuelUsePerLap { get; set; }
         public float FuelPerLap { get; set; }
+        public float FuelCapacity { get; set; }
         public float LapDistTotal { get; set; }
         public float FuelUsedTotal { get; set; }
 

--- a/backend/Services/IRacingTelemetryService.cs
+++ b/backend/Services/IRacingTelemetryService.cs
@@ -188,6 +188,7 @@ namespace SuperBackendNR85IA.Services
             t.Gear                = GetSdkValue<int>(d, "Gear") ?? 0;
             t.FuelLevel           = GetSdkValue<float>(d, "FuelLevel") ?? 0f;
             t.FuelLevelPct        = GetSdkValue<float>(d, "FuelLevelPct") ?? 0f;
+            t.FuelCapacity        = t.FuelLevelPct > 0f ? t.FuelLevel / t.FuelLevelPct : 0f;
             t.WaterTemp           = GetSdkValue<float>(d, "WaterTemp") ?? 0f;
             t.OilTemp             = GetSdkValue<float>(d, "OilTemp") ?? 0f;
             t.OilPress            = GetSdkValue<float>(d, "OilPress") ?? 0f;

--- a/telemetry-frontend/public/antigasoverlays/overlay-tanque.html
+++ b/telemetry-frontend/public/antigasoverlays/overlay-tanque.html
@@ -584,10 +584,11 @@
     const necessarioFimValor       = document.getElementById('necessarioFimValor');
     const statusValor              = document.getElementById('statusValor');
     const recomendacaoAbastecimento= document.getElementById('recomendacaoAbastecimentoValor');
-    const capacidadeTotalTanque    = 80; // Valor fixo da sua overlay original
+    let capacidadeTotalTanque    = 80; // Valor padrão caso backend não envie
 
     function updateFuelCalculator(data) {
-      const atual = data.tanqueAtual ?? 0;
+      capacidadeTotalTanque = data.fuelCapacity ?? data.FuelCapacity ?? capacidadeTotalTanque;
+      const atual = data.tanqueAtual ?? data.fuelLevel ?? 0;
       tanqueAtualValor.textContent = `${atual.toFixed(1)}L`;
       const pct = Math.max(0, Math.min(100, (atual / capacidadeTotalTanque) * 100));
       barraTanque.style.width = `${pct}%`;

--- a/telemetry-frontend/public/overlays/overlay-tanque.html
+++ b/telemetry-frontend/public/overlays/overlay-tanque.html
@@ -601,9 +601,10 @@
     const necessarioFimValor       = document.getElementById('necessarioFimValor');
     const statusValor              = document.getElementById('statusValor');
     const recomendacaoAbastecimentoValor = document.getElementById('recomendacaoAbastecimentoValor'); // Corrigido o ID
-    const capacidadeTotalTanque    = 80; // Exemplo, idealmente viria do YAML ou config
+    let capacidadeTotalTanque    = 80; // valor padrão caso backend não envie
 
     function updateFuelCalculator(model) {
+        capacidadeTotalTanque = model.fuelCapacity ?? model.FuelCapacity ?? capacidadeTotalTanque;
         // Tanque Atual e Barra
         const atual = model.fuelLevel ?? model.FuelLevel ?? 0; // camelCase ou PascalCase
         tanqueAtualValor.textContent = `${atual.toFixed(1)}L`;


### PR DESCRIPTION
## Summary
- send fuel capacity from the backend
- read fuel capacity in overlays

## Testing
- `dotnet --version`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684213affa5c8330bb77f3b8fb9573b6