### PR TITLE
Fix fuel calculations and overlay field names

### DIFF
--- a/backend/Models/TelemetryCalculationsOverlay.cs
+++ b/backend/Models/TelemetryCalculationsOverlay.cs
@@ -15,8 +15,14 @@ namespace SuperBackendNR85IA.Calculations
                 model.FuelUsePerLap
             );
 
-            model.ConsumoMedio = model.FuelUsePerLap;
-            model.LapsRemaining = (int)TelemetryCalculations.GetFuelLapsLeft(model.FuelLevel, model.FuelUsePerLap);
+            model.ConsumoVoltaAtual = model.FuelUsePerLap;
+
+            model.LapsRemaining = (int)TelemetryCalculations.GetFuelLapsLeft(model.FuelLevel, model.ConsumoVoltaAtual);
+
+            float lapsEfetivos = (model.Lap > 0) ? ((model.Lap - 1) + model.LapDistPct) : model.LapDistPct;
+            model.ConsumoMedio = (lapsEfetivos > 0 && model.FuelUsedTotal > 0)
+                ? model.FuelUsedTotal / lapsEfetivos
+                : 0f;
             model.VoltasRestantesMedio = model.ConsumoMedio > 0 ? model.FuelLevel / model.ConsumoMedio : 0;
             model.NecessarioFim = (float)TelemetryCalculations.GetFuelForTargetLaps(
                 model.LapsRemainingRace, model.ConsumoMedio);

--- a/backend/Models/TelemetryModel.cs
+++ b/backend/Models/TelemetryModel.cs
@@ -204,6 +204,7 @@ namespace SuperBackendNR85IA.Models
         // Valores calculados
         public float FuelUsePerLapCalc { get; set; }
         public float EstLapTimeCalc { get; set; }
+        public float ConsumoVoltaAtual { get; set; }
         public int LapsRemaining { get; set; }
         public float ConsumoMedio { get; set; }
         public float VoltasRestantesMedio { get; set; }

--- a/backend/Services/IRacingTelemetryService.cs
+++ b/backend/Services/IRacingTelemetryService.cs
@@ -533,13 +533,18 @@ namespace SuperBackendNR85IA.Services
                 t.FuelUsePerLapCalc = t.FuelUsePerLap;
                 t.EstLapTimeCalc    = t.EstLapTime;
 
+                t.ConsumoVoltaAtual = t.FuelUsePerLap;
+
                 double lapsLeftWithCurrentFuel = TelemetryCalculations.GetFuelLapsLeft(
                     t.FuelLevel,
-                    t.FuelUsePerLap
+                    t.ConsumoVoltaAtual
                 );
                 t.LapsRemaining = (int)Math.Floor(lapsLeftWithCurrentFuel);
 
-                t.ConsumoMedio = (t.Lap > 0 && t.FuelUsedTotal > 0) ? (t.FuelUsedTotal / t.Lap) : 0;
+                float lapsEfetivos = (t.Lap > 0) ? ((t.Lap - 1) + t.LapDistPct) : t.LapDistPct;
+                t.ConsumoMedio = (lapsEfetivos > 0 && t.FuelUsedTotal > 0)
+                    ? (t.FuelUsedTotal / lapsEfetivos)
+                    : 0;
                 t.VoltasRestantesMedio = (t.ConsumoMedio > 0) ? (t.FuelLevel / t.ConsumoMedio) : 0;
 
                 if (t.TotalLaps > 0)
@@ -554,12 +559,12 @@ namespace SuperBackendNR85IA.Services
                         : 0;
                 }
 
-                float fuelNeededForRaceLaps = (t.LapsRemainingRace > 0 && t.FuelUsePerLap > 0)
-                    ? (t.LapsRemainingRace * t.FuelUsePerLap) : 0;
-                t.NecessarioFim = Math.Max(0, fuelNeededForRaceLaps - t.FuelLevel);
+                float fuelNeededForRaceLaps = (t.LapsRemainingRace > 0 && t.ConsumoMedio > 0)
+                    ? (t.LapsRemainingRace * t.ConsumoMedio) : 0;
+                t.NecessarioFim = fuelNeededForRaceLaps;
 
-                float safetyMarginLiters = (t.FuelUsePerLap > 0) ? (t.FuelUsePerLap * 2) : 1.0f;
-                t.RecomendacaoAbastecimento = Math.Max(0, t.NecessarioFim + safetyMarginLiters);
+                float faltante = fuelNeededForRaceLaps - t.FuelLevel;
+                t.RecomendacaoAbastecimento = Math.Max(0, faltante);
 
                 t.FuelRemaining = t.FuelLevel;
                 t.FuelEta       = t.LapsRemaining * t.EstLapTime;

--- a/telemetry-frontend/public/overlays/overlay-tanque.html
+++ b/telemetry-frontend/public/overlays/overlay-tanque.html
@@ -622,11 +622,12 @@
         }
 
 
-        // Consumo por Volta (instantâneo/recente do SDK)
-        const fuelLap = model.fuelUsePerLap ?? model.fuelPerLap ??
+        // Consumo da volta atual
+        const fuelLap = model.consumoVoltaAtual ?? model.ConsumoVoltaAtual ??
+                        model.fuelUsePerLap ?? model.fuelPerLap ??
                         model.FuelUsePerLap ?? model.FuelPerLap ??
                         model.fuelUsePerLapCalc ?? model.FuelUsePerLapCalc ?? 0;
-        consumoPorVoltaValor.textContent = `${fuelLap.toFixed(2)}L`; // fuelUsePerLap
+        consumoPorVoltaValor.textContent = `${fuelLap.toFixed(2)}L`;
 
         // Voltas Restantes (com base no consumo atual/instantâneo)
         voltasRestantesAtualValor.textContent = Math.floor(model.lapsRemaining ?? model.LapsRemaining ?? 0); // lapsRemaining


### PR DESCRIPTION
## Summary
- improve backend fuel calculations and expose `ConsumoVoltaAtual`
- use average consumption for fuel estimates
- display new property in fuel overlay

## Testing
- `dotnet build` *(fails: command not found)*
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684220be6a948330b29d4dc4356cbc1d