### PR TITLE
Calcular consumo da volta via diferenca de combustivel

### DIFF
--- a/backend/Models/TelemetryCalculationsOverlay.cs
+++ b/backend/Models/TelemetryCalculationsOverlay.cs
@@ -15,7 +15,7 @@ namespace SuperBackendNR85IA.Calculations
                 model.FuelUsePerLap
             );
 
-            model.ConsumoVoltaAtual = model.FuelUsePerLap;
+            model.ConsumoVoltaAtual = model.FuelLevelLapStart - model.FuelLevel;
 
             model.LapsRemaining = (int)TelemetryCalculations.GetFuelLapsLeft(model.FuelLevel, model.ConsumoVoltaAtual);
 

--- a/backend/Models/TelemetryModel.cs
+++ b/backend/Models/TelemetryModel.cs
@@ -199,6 +199,7 @@ namespace SuperBackendNR85IA.Models
         public float FuelPerLap { get; set; }
         public float FuelCapacity { get; set; }
         public float LapDistTotal { get; set; }
+        public float FuelLevelLapStart { get; set; }
         public float FuelUsedTotal { get; set; }
 
         // Valores calculados

--- a/backend/Services/IRacingTelemetryService.cs
+++ b/backend/Services/IRacingTelemetryService.cs
@@ -23,6 +23,8 @@ namespace SuperBackendNR85IA.Services
         private string _lastYaml = string.Empty;
         private (DriverInfo? Drv, WeekendInfo? Wkd, SessionInfo? Ses,SectorInfo Sec) _cachedYamlData;
         private int _lastTick = -1;
+        private int _lastLap = -1;
+        private float _fuelAtLapStart = 0f;
 
         public IRacingTelemetryService(ILogger<IRacingTelemetryService> log, TelemetryBroadcaster broadcaster)
         {
@@ -213,6 +215,13 @@ namespace SuperBackendNR85IA.Services
             t.LapDeltaToSessionBestLap    = GetSdkValue<float>(d, "LapDeltaToSessionBestLap") ?? 0f;
             t.LapDeltaToSessionOptimalLap = GetSdkValue<float>(d, "LapDeltaToSessionOptimalLap") ?? 0f;
             t.LapDeltaToDriverBestLap     = GetSdkValue<float>(d, "LapDeltaToPlayerBestLap") ?? 0f;
+
+            if (t.Lap != _lastLap)
+            {
+                _lastLap = t.Lap;
+                _fuelAtLapStart = t.FuelLevel;
+            }
+            t.FuelLevelLapStart = _fuelAtLapStart;
 
             // ─────────────────────────────────────────────────────────────────────────
             // Coleta de SETORES (arrays prontas do SDK)
@@ -533,7 +542,7 @@ namespace SuperBackendNR85IA.Services
                 t.FuelUsePerLapCalc = t.FuelUsePerLap;
                 t.EstLapTimeCalc    = t.EstLapTime;
 
-                t.ConsumoVoltaAtual = t.FuelUsePerLap;
+                t.ConsumoVoltaAtual = _fuelAtLapStart - t.FuelLevel;
 
                 double lapsLeftWithCurrentFuel = TelemetryCalculations.GetFuelLapsLeft(
                     t.FuelLevel,


### PR DESCRIPTION
## Summary
- store fuel level at the beginning of each lap
- expose `FuelLevelLapStart` on TelemetryModel
- calcular consumo da volta como diferenca entre inicio de volta e nivel atual

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684237b4be348330af18b9c38ed6f23f