### PR TITLE
Use lap start to calculate per-lap fuel usage

### DIFF
--- a/telemetry-frontend/public/overlays/overlay-tanque.html
+++ b/telemetry-frontend/public/overlays/overlay-tanque.html
@@ -623,10 +623,14 @@
 
 
         // Consumo da volta atual
-        const fuelLap = model.consumoVoltaAtual ?? model.ConsumoVoltaAtual ??
-                        model.fuelUsePerLap ?? model.fuelPerLap ??
-                        model.FuelUsePerLap ?? model.FuelPerLap ??
-                        model.fuelUsePerLapCalc ?? model.FuelUsePerLapCalc ?? 0;
+        const lapStart = model.fuelLevelLapStart ?? model.FuelLevelLapStart ?? atual;
+        let fuelLap = lapStart - atual;
+        if (fuelLap <= 0) {
+            fuelLap = model.consumoVoltaAtual ?? model.ConsumoVoltaAtual ??
+                       model.fuelUsePerLap ?? model.fuelPerLap ??
+                       model.FuelUsePerLap ?? model.FuelPerLap ??
+                       model.fuelUsePerLapCalc ?? model.FuelUsePerLapCalc ?? 0;
+        }
         consumoPorVoltaValor.textContent = `${fuelLap.toFixed(2)}L`;
 
         // Voltas Restantes (com base no consumo atual/instantâneo)


### PR DESCRIPTION
## Summary
- compute fuel consumed this lap from `fuelLevelLapStart` and fallback to existing fields
- show this value for `Consumo da volta atual`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68424bb65abc83308585bc6983650d94