### PR TITLE
Handle lap fuel usage without per-lap reset

### DIFF
--- a/backend/Models/TelemetryCalculationsOverlay.cs
+++ b/backend/Models/TelemetryCalculationsOverlay.cs
@@ -15,7 +15,21 @@ namespace SuperBackendNR85IA.Calculations
                 model.FuelUsePerLap
             );
 
-            model.ConsumoVoltaAtual = model.FuelLevelLapStart - model.FuelLevel;
+            float diffLap = model.FuelLevelLapStart - model.FuelLevel;
+            if (diffLap > 0)
+                model.ConsumoVoltaAtual = diffLap;
+            if (model.ConsumoVoltaAtual <= 0)
+            {
+                float[] opts = { model.FuelUsePerLap, model.FuelPerLap, model.FuelUsePerLapCalc };
+                foreach (var opt in opts)
+                {
+                    if (opt > 0)
+                    {
+                        model.ConsumoVoltaAtual = opt;
+                        break;
+                    }
+                }
+            }
 
             model.LapsRemaining = (int)TelemetryCalculations.GetFuelLapsLeft(model.FuelLevel, model.ConsumoVoltaAtual);
 


### PR DESCRIPTION
## Summary
- track `ConsumoVoltaAtual` across laps
- reset fuel usage only when session changes
- keep last known usage in overlay calculations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68424bb65abc83308585bc6983650d94