### PR TITLE
Add last-lap fuel info and persist car/track data

### DIFF
--- a/backend/Models/TelemetryModel.cs
+++ b/backend/Models/TelemetryModel.cs
@@ -209,6 +209,8 @@ namespace SuperBackendNR85IA.Models
         public int LapsRemaining { get; set; }
         public float ConsumoMedio { get; set; }
         public float VoltasRestantesMedio { get; set; }
+        public float ConsumoUltimaVolta { get; set; }
+        public float VoltasRestantesUltimaVolta { get; set; }
         public float NecessarioFim { get; set; }
         public float RecomendacaoAbastecimento { get; set; }
         public float FuelRemaining { get; set; }

--- a/backend/Services/CarTrackDataStore.cs
+++ b/backend/Services/CarTrackDataStore.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace SuperBackendNR85IA.Services
+{
+    public class CarTrackData
+    {
+        public string CarPath { get; set; } = string.Empty;
+        public string TrackName { get; set; } = string.Empty;
+        public float ConsumoMedio { get; set; }
+        public float ConsumoUltimaVolta { get; set; }
+        public float FuelCapacity { get; set; }
+    }
+
+    public class CarTrackDataStore
+    {
+        private const string FilePath = "carTrackData.json";
+        private readonly object _lock = new();
+        private Dictionary<string, CarTrackData> _data = new();
+
+        public CarTrackDataStore()
+        {
+            try
+            {
+                if (File.Exists(FilePath))
+                {
+                    var json = File.ReadAllText(FilePath);
+                    _data = JsonSerializer.Deserialize<Dictionary<string, CarTrackData>>(json) ?? new();
+                }
+            }
+            catch { _data = new(); }
+        }
+
+        private string Key(string carPath, string trackName) => $"{carPath}::{trackName}";
+
+        public CarTrackData Get(string carPath, string trackName)
+        {
+            lock (_lock)
+            {
+                var key = Key(carPath, trackName);
+                if (_data.TryGetValue(key, out var d))
+                    return d;
+                d = new CarTrackData { CarPath = carPath, TrackName = trackName };
+                _data[key] = d;
+                return d;
+            }
+        }
+
+        public void Update(CarTrackData d)
+        {
+            lock (_lock)
+            {
+                var key = Key(d.CarPath, d.TrackName);
+                _data[key] = d;
+                try
+                {
+                    var json = JsonSerializer.Serialize(_data, new JsonSerializerOptions { WriteIndented = true });
+                    File.WriteAllText(FilePath, json);
+                }
+                catch { }
+            }
+        }
+    }
+}

--- a/backend/Services/IRacingTelemetryService.cs
+++ b/backend/Services/IRacingTelemetryService.cs
@@ -26,7 +26,11 @@ namespace SuperBackendNR85IA.Services
         private int _lastLap = -1;
         private float _fuelAtLapStart = 0f;
         private float _consumoVoltaAtual = 0f;
+        private float _consumoUltimaVolta = 0f;
         private int _lastSessionNum = -1;
+        private readonly CarTrackDataStore _store = new();
+        private string _carPath = string.Empty;
+        private string _trackName = string.Empty;
 
         public IRacingTelemetryService(ILogger<IRacingTelemetryService> log, TelemetryBroadcaster broadcaster)
         {
@@ -220,8 +224,11 @@ namespace SuperBackendNR85IA.Services
 
             if (t.Lap != _lastLap)
             {
+                if (_lastLap >= 0)
+                    _consumoUltimaVolta = _consumoVoltaAtual;
                 _lastLap = t.Lap;
                 _fuelAtLapStart = t.FuelLevel;
+                _consumoVoltaAtual = 0f;
             }
             t.FuelLevelLapStart = _fuelAtLapStart;
 
@@ -353,11 +360,14 @@ namespace SuperBackendNR85IA.Services
             t.SessionNum        = GetSdkValue<int>(d, "SessionNum") ?? 0;
             t.SessionTime       = GetSdkValue<float>(d, "SessionTime") ?? 0f;
             t.SessionTimeRemain = GetSdkValue<float>(d, "SessionTimeRemain") ?? 0f;
+            bool sessionChanged = false;
             if (t.SessionNum != _lastSessionNum)
             {
+                sessionChanged = true;
                 _lastSessionNum = t.SessionNum;
                 _fuelAtLapStart = t.FuelLevel;
                 _consumoVoltaAtual = 0f;
+                _consumoUltimaVolta = 0f;
                 _lastLap = t.Lap;
             }
             t.SessionState      = GetSdkValue<int>(d, "SessionState") ?? 0;
@@ -530,6 +540,15 @@ namespace SuperBackendNR85IA.Services
                 t.ChanceOfRain        = wkd.ChanceOfRain;
             }
 
+            if (sessionChanged)
+            {
+                _carPath = drv?.CarPath ?? string.Empty;
+                _trackName = wkd?.TrackDisplayName ?? string.Empty;
+                var saved = _store.Get(_carPath, _trackName);
+                _consumoUltimaVolta = saved.ConsumoUltimaVolta;
+                t.ConsumoMedio = saved.ConsumoMedio;
+            }
+
             if (ses != null)
             {
                 t.IncidentLimit = ses.IncidentLimit;
@@ -574,6 +593,9 @@ namespace SuperBackendNR85IA.Services
                     t.ConsumoVoltaAtual
                 );
                 t.LapsRemaining = (int)Math.Floor(lapsLeftWithCurrentFuel);
+                t.ConsumoUltimaVolta = _consumoUltimaVolta;
+                t.VoltasRestantesUltimaVolta = _consumoUltimaVolta > 0 ?
+                    t.FuelLevel / _consumoUltimaVolta : 0f;
 
                 float lapsEfetivos = (t.Lap > 0) ? ((t.Lap - 1) + t.LapDistPct) : t.LapDistPct;
                 t.ConsumoMedio = (lapsEfetivos > 0 && t.FuelUsedTotal > 0)
@@ -631,6 +653,15 @@ namespace SuperBackendNR85IA.Services
                 t.RecomendacaoAbastecimento = 0;
                 t.FuelStatus = new FuelStatus { Text = "ERRO", Class = "status-danger" };
             }
+
+            _store.Update(new CarTrackData
+            {
+                CarPath = _carPath,
+                TrackName = _trackName,
+                ConsumoMedio = t.ConsumoMedio,
+                ConsumoUltimaVolta = _consumoUltimaVolta,
+                FuelCapacity = t.FuelCapacity
+            });
 
             return t;
         }

--- a/telemetry-frontend/public/overlays/overlay-tanque.html
+++ b/telemetry-frontend/public/overlays/overlay-tanque.html
@@ -242,6 +242,17 @@
 
       <div class="grid grid-cols-2 gap-4 mb-3">
         <div class="text-center">
+          <div id="consumoUltimaVoltaValor" class="text-green-400 text-lg font-bold">0.00L</div>
+          <div class="text-xs text-gray-300">Última Volta</div>
+        </div>
+        <div class="text-center">
+          <div id="voltasRestantesUltimaValor" class="text-blue-400 text-lg font-bold">0</div>
+          <div class="text-xs text-gray-300">Voltas (Última)</div>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-2 gap-4 mb-3">
+        <div class="text-center">
           <div id="consumoMedioValor" class="text-green-300 text-lg font-bold">0.00L</div>
           <div class="text-xs text-gray-300">Consumo Médio</div>
         </div>
@@ -596,6 +607,8 @@
     const barraTanque              = document.getElementById('barraTanque');
     const consumoPorVoltaValor     = document.getElementById('consumoPorVoltaValor');
     const voltasRestantesAtualValor= document.getElementById('voltasRestantesAtualValor');
+    const consumoUltimaVoltaValor  = document.getElementById('consumoUltimaVoltaValor');
+    const voltasRestantesUltimaValor = document.getElementById('voltasRestantesUltimaValor');
     const consumoMedioValor        = document.getElementById('consumoMedioValor');
     const voltasRestantesMedioValor= document.getElementById('voltasRestantesMedioValor');
     const necessarioFimValor       = document.getElementById('necessarioFimValor');
@@ -635,6 +648,9 @@
 
         // Voltas Restantes (com base no consumo atual/instantâneo)
         voltasRestantesAtualValor.textContent = Math.floor(model.lapsRemaining ?? model.LapsRemaining ?? 0); // lapsRemaining
+
+        consumoUltimaVoltaValor.textContent = `${(model.consumoUltimaVolta ?? model.ConsumoUltimaVolta ?? 0).toFixed(2)}L`;
+        voltasRestantesUltimaValor.textContent = Math.floor(model.voltasRestantesUltimaVolta ?? model.VoltasRestantesUltimaVolta ?? 0);
 
         // Consumo Médio
         consumoMedioValor.textContent = `${(model.consumoMedio ?? model.ConsumoMedio ?? 0).toFixed(2)}L`; // consumoMedio


### PR DESCRIPTION
## Summary
- track last lap fuel consumption and remaining laps
- persist car/track info across sessions on backend
- show last lap data in overlay

## Testing
- `dotnet build` *(fails: command not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68439e5ce0e883309788181360e6826f