### PR TITLE
Improve data store persistence with async operations

### DIFF
--- a/backend/Services/CarTrackDataStore.cs
+++ b/backend/Services/CarTrackDataStore.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
+using System.Threading.Tasks;
 
 namespace SuperBackendNR85IA.Services
 {
@@ -21,8 +22,12 @@ namespace SuperBackendNR85IA.Services
         private static readonly string FilePath = Path.Combine(
             AppContext.BaseDirectory,
             "carTrackData.json");
+        private const int SAVE_INTERVAL_SECONDS = 5;
+
         private readonly object _lock = new();
         private Dictionary<string, CarTrackData> _data = new();
+        private DateTime _lastPersist = DateTime.UtcNow;
+        private bool _dirty = false;
 
         public CarTrackDataStore()
         {
@@ -30,7 +35,7 @@ namespace SuperBackendNR85IA.Services
             {
                 if (File.Exists(FilePath))
                 {
-                    var json = File.ReadAllText(FilePath);
+                    var json = File.ReadAllTextAsync(FilePath).GetAwaiter().GetResult();
                     _data = JsonSerializer.Deserialize<Dictionary<string, CarTrackData>>(json) ?? new();
                 }
             }
@@ -39,32 +44,58 @@ namespace SuperBackendNR85IA.Services
 
         private string Key(string carPath, string trackName) => $"{carPath}::{trackName}";
 
-        public CarTrackData Get(string carPath, string trackName)
+        public Task<CarTrackData> GetAsync(string carPath, string trackName)
         {
             lock (_lock)
             {
                 var key = Key(carPath, trackName);
                 if (_data.TryGetValue(key, out var d))
-                    return d;
+                    return Task.FromResult(d);
                 d = new CarTrackData { CarPath = carPath, TrackName = trackName };
                 _data[key] = d;
-                return d;
+                return Task.FromResult(d);
             }
         }
 
-        public void Update(CarTrackData d)
+        public async Task UpdateAsync(CarTrackData d)
         {
+            bool shouldPersist = false;
             lock (_lock)
             {
                 var key = Key(d.CarPath, d.TrackName);
                 _data[key] = d;
-                try
+                _dirty = true;
+                if ((DateTime.UtcNow - _lastPersist).TotalSeconds >= SAVE_INTERVAL_SECONDS)
                 {
-                    var json = JsonSerializer.Serialize(_data, new JsonSerializerOptions { WriteIndented = true });
-                    File.WriteAllText(FilePath, json);
+                    shouldPersist = true;
                 }
-                catch { }
             }
+
+            if (shouldPersist)
+            {
+                await PersistAsync();
+            }
+        }
+
+        public Task SaveAsync() => PersistAsync();
+
+        private async Task PersistAsync()
+        {
+            Dictionary<string, CarTrackData> snapshot;
+            lock (_lock)
+            {
+                if (!_dirty)
+                    return;
+                snapshot = new Dictionary<string, CarTrackData>(_data);
+                _dirty = false;
+                _lastPersist = DateTime.UtcNow;
+            }
+            try
+            {
+                var json = JsonSerializer.Serialize(snapshot, new JsonSerializerOptions { WriteIndented = true });
+                await File.WriteAllTextAsync(FilePath, json);
+            }
+            catch { }
         }
     }
 }

--- a/backend/Services/IRacingTelemetryService.cs
+++ b/backend/Services/IRacingTelemetryService.cs
@@ -72,7 +72,7 @@ namespace SuperBackendNR85IA.Services
 
                     if (_sdk.Data != null && _sdk.Data.TickCount != _lastTick)
                     {
-                        var telemetryModel = BuildTelemetryModel();
+                        var telemetryModel = await BuildTelemetryModelAsync();
                         if (telemetryModel != null)
                         {
                             TelemetryCalculationsOverlay.PreencherOverlayTanque(ref telemetryModel);
@@ -187,7 +187,7 @@ namespace SuperBackendNR85IA.Services
             }
         }
 
-        private TelemetryModel? BuildTelemetryModel()
+        private async Task<TelemetryModel?> BuildTelemetryModelAsync()
         {
             if (_sdk.Data == null) return null;
 
@@ -591,7 +591,7 @@ namespace SuperBackendNR85IA.Services
 
             if (_awaitingStoredData && !string.IsNullOrEmpty(_carPath) && !string.IsNullOrEmpty(_trackName))
             {
-                var saved = _store.Get(_carPath, _trackName);
+                var saved = await _store.GetAsync(_carPath, _trackName);
                 _consumoUltimaVolta = saved.ConsumoUltimaVolta;
                 t.ConsumoMedio = saved.ConsumoMedio;
 
@@ -713,7 +713,7 @@ namespace SuperBackendNR85IA.Services
 
             if (!string.IsNullOrEmpty(_carPath) && !string.IsNullOrEmpty(_trackName))
             {
-                _store.Update(new CarTrackData
+                await _store.UpdateAsync(new CarTrackData
                 {
                     CarPath = _carPath,
                     TrackName = _trackName,


### PR DESCRIPTION
## Summary
- switch to async file I/O in `CarTrackDataStore`
- buffer updates in memory and periodically persist
- expose `GetAsync` and `UpdateAsync` and await them from `IRacingTelemetryService`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b8c9d1808330ba0c7f0de76529c1