### PR TITLE
Deduplicate overlay calculations

### DIFF
--- a/backend/Models/TelemetryCalculationsOverlay.cs
+++ b/backend/Models/TelemetryCalculationsOverlay.cs
@@ -1,6 +1,5 @@
 // Extensões de cálculo e preenchimento para overlays
 using System;
-using System.Linq;
 using SuperBackendNR85IA.Models;
 
 namespace SuperBackendNR85IA.Calculations
@@ -9,49 +8,9 @@ namespace SuperBackendNR85IA.Calculations
     {
         public static void PreencherOverlayTanque(ref TelemetryModel model)
         {
-            model.FuelUsePerLap = TelemetryCalculations.CalculateFuelPerLap(
-                model.FuelUsedTotal,
-                model.LapDistPct,
-                model.LapLastLapTime,
-                model.Lap,
-                model.FuelUsePerLap
-            );
-
-            float diffLap = model.FuelLevelLapStart - model.FuelLevel;
-            if (diffLap > 0 && !model.OnPitRoad)
-                model.ConsumoVoltaAtual = diffLap;
-            if (model.ConsumoVoltaAtual <= 0)
-            {
-                float[] opts = { model.FuelUsePerLap, model.FuelPerLap, model.FuelUsePerLapCalc };
-                foreach (var opt in opts)
-                {
-                    if (opt > 0)
-                    {
-                        model.ConsumoVoltaAtual = opt;
-                        break;
-                    }
-                }
-            }
-
-            model.LapsRemaining = (int)TelemetryCalculations.GetFuelLapsLeft(model.FuelLevel, model.ConsumoVoltaAtual);
-
-            // --- Cálculo de Consumo Médio ---
-            float lapsEfetivos = model.Lap + model.LapDistPct;
-            float novoConsumoMedio = (lapsEfetivos > 0.5f && model.FuelUsedTotal > 0)
-                ? model.FuelUsedTotal / lapsEfetivos
-                : 0f;
-            if (novoConsumoMedio > 0)
-                model.ConsumoMedio = novoConsumoMedio;
-            // Agora os cálculos que dependem do ConsumoMedio
-            model.VoltasRestantesMedio = model.ConsumoMedio > 0
-                ? model.FuelLevel / model.ConsumoMedio
-                : 0;
-            model.NecessarioFim = (float)TelemetryCalculations.GetFuelForTargetLaps(
-                model.LapsRemainingRace, model.ConsumoMedio);
+            TelemetryCalculations.UpdateFuelData(ref model);
 
             float faltante = model.NecessarioFim - model.FuelLevel;
-            model.RecomendacaoAbastecimento = MathF.Max(0, faltante);
-
             model.FuelStatus = new FuelStatus();
             if (faltante <= 0)
             {
@@ -85,31 +44,7 @@ namespace SuperBackendNR85IA.Calculations
 
         public static void PreencherOverlaySetores(ref TelemetryModel model)
         {
-            if (model.LapAllSectorTimes == null || model.LapAllSectorTimes.Length != model.SectorCount)
-                model.LapAllSectorTimes = new float[model.SectorCount];
-
-            if (model.LapDeltaToSessionBestSectorTimes == null || model.LapDeltaToSessionBestSectorTimes.Length != model.SectorCount)
-                model.LapDeltaToSessionBestSectorTimes = new float[model.SectorCount];
-
-            if (model.SessionBestSectorTimes == null || model.SessionBestSectorTimes.Length != model.SectorCount)
-                model.SessionBestSectorTimes = new float[model.SectorCount];
-
-            if (model.LapAllSectorTimes.All(v => v == 0f) && model.LapLastLapTime > 0 && model.SectorCount > 0)
-                for (int i = 0; i < model.SectorCount; i++)
-                    model.LapAllSectorTimes[i] = model.LapLastLapTime / model.SectorCount;
-
-            if (model.SessionBestSectorTimes.All(v => v == 0f) && model.LapBestLapTime > 0 && model.SectorCount > 0)
-                for (int i = 0; i < model.SectorCount; i++)
-                    model.SessionBestSectorTimes[i] = model.LapBestLapTime / model.SectorCount;
-
-            if (model.LapDeltaToSessionBestSectorTimes.All(v => v == 0f) && model.LapAllSectorTimes.Length == model.SessionBestSectorTimes.Length)
-                for (int i = 0; i < model.SectorCount; i++)
-                    model.LapDeltaToSessionBestSectorTimes[i] = model.LapAllSectorTimes[i] - model.SessionBestSectorTimes[i];
-
-            // Estimativa de volta ideal com base em soma dos melhores setores
-            model.EstLapTime = 0f;
-            foreach (var setor in model.SessionBestSectorTimes)
-                model.EstLapTime += setor;
+            TelemetryCalculations.UpdateSectorData(ref model);
         }
 
         public static void PreencherOverlayDelta(ref TelemetryModel model)

--- a/backend/Services/IRacingTelemetryService.cs
+++ b/backend/Services/IRacingTelemetryService.cs
@@ -281,45 +281,11 @@ namespace SuperBackendNR85IA.Services
             if (t.SessionBestSectorTimes.Length == 0 && sec?.BestSectorTimes?.Length > 0)
                 t.SessionBestSectorTimes = sec.BestSectorTimes;
 
-            // Delta piloto × melhores setores da sessão — pré-2023: "LapDeltaToSessionBestSectorTimes" | 2023+: "SectorTimeDeltaSessionBestLap"
-            if (t.LapAllSectorTimes.Length > 0 && t.SessionBestSectorTimes.Length == t.LapAllSectorTimes.Length)
-            {
-                int count = t.LapAllSectorTimes.Length;
-                var deltas = new float[count];
-                for (int i = 0; i < count; i++)
-                {
-                    var tp = t.LapAllSectorTimes[i];
-                    var ts = t.SessionBestSectorTimes[i];
-                    if (tp > 1e-4f && ts > 1e-4f)
-                        deltas[i] = tp - ts;
-                    else
-                        deltas[i] = 0f;
-                }
-                t.LapDeltaToSessionBestSectorTimes = deltas;
-            }
-            else
-            {
-                t.LapDeltaToSessionBestSectorTimes = Arr("LapDeltaToSessionBestSectorTimes", "SectorTimeDeltaSessionBestLap");
-            }
-
             t.SectorCount = Math.Max(Math.Max(t.LapAllSectorTimes.Length, t.SessionBestSectorTimes.Length), sec?.SectorCount ?? 0);
             if (t.SectorCount <= 0)
                 t.SectorCount = 3;
 
-            if (t.LapAllSectorTimes.Length == 0 && t.LapLastLapTime > 0 && t.SectorCount > 0)
-                t.LapAllSectorTimes = Enumerable.Repeat(t.LapLastLapTime / t.SectorCount, t.SectorCount).ToArray();
-
-            if (t.SessionBestSectorTimes.Length == 0 && t.LapBestLapTime > 0 && t.SectorCount > 0)
-                t.SessionBestSectorTimes = Enumerable.Repeat(t.LapBestLapTime / t.SectorCount, t.SectorCount).ToArray();
-
-            if (t.LapDeltaToSessionBestSectorTimes.Length == 0 && t.LapAllSectorTimes.Length == t.SessionBestSectorTimes.Length)
-            {
-                int count = t.SectorCount;
-                var deltas = new float[count];
-                for (int i = 0; i < count; i++)
-                    deltas[i] = t.LapAllSectorTimes[i] - t.SessionBestSectorTimes[i];
-                t.LapDeltaToSessionBestSectorTimes = deltas;
-            }
+            TelemetryCalculations.UpdateSectorData(ref t);
 
             // Optimal Lap Time — tenta "LapOptimalLapTime" se existir, senão soma dos melhores setores
             var lapOpt = GetSdkValue<float>(d, "LapOptimalLapTime") ?? 0f;


### PR DESCRIPTION
## Summary
- centralize overlay calculations in TelemetryCalculations
- call the shared helpers from overlay and service classes

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b8ce85448330994381c75143142d