### PR TITLE
Fix overlay websocket URL

### DIFF
--- a/telemetry-frontend/public/overlay-common.js
+++ b/telemetry-frontend/public/overlay-common.js
@@ -1,7 +1,7 @@
 let socket;
 
 function initOverlayWebSocket(onData) {
-  const url = `ws://${window.location.hostname}:3000/ws`;
+  const url = window.OVERLAY_WS_URL || `ws://${window.location.hostname}:5221/ws`;
   function connect() {
     socket = new WebSocket(url);
     socket.onmessage = (e) => {


### PR DESCRIPTION
## Summary
- ensure overlays use same WebSocket port as backend

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844e913d0bc833098c98827f418645d