### PR TITLE
Fix overlay host default to localhost

### DIFF
--- a/telemetry-frontend/public/overlay-common.js
+++ b/telemetry-frontend/public/overlay-common.js
@@ -1,7 +1,8 @@
 let socket;
 
 function initOverlayWebSocket(onData) {
-  const url = window.OVERLAY_WS_URL || `ws://${window.location.hostname}:5221/ws`;
+  const host = window.location.hostname || 'localhost';
+  const url = window.OVERLAY_WS_URL || `ws://${host}:5221/ws`;
   function connect() {
     socket = new WebSocket(url);
     socket.onmessage = (e) => {


### PR DESCRIPTION
## Summary
- default overlay websocket host to `localhost`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68450f4522a8833086dcd61209052561