### PR TITLE
Handle cancellation when server stops

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -35,7 +35,7 @@ app.Map("/ws", async context =>
     {
         var webSocket = await context.WebSockets.AcceptWebSocketAsync();
         var handler = context.RequestServices.GetRequiredService<TelemetryBroadcaster>();
-        await handler.AddClient(webSocket); // Certifique-se que o método AddClient em TelemetryBroadcaster existe e é público
+        await handler.AddClient(webSocket, context.RequestAborted); // passa o CancellationToken para permitir cancelamento gracioso
     }
     else
     {


### PR DESCRIPTION
## Summary
- forward the request's cancellation token to the telemetry broadcaster
- allow AddClient to consume a `CancellationToken` so receives stop gracefully

## Testing
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68450f47bb20833095a16a11cc4bd794