### PR TITLE
Fix WebSocket host fallback

### DIFF
--- a/telemetry-frontend/public/overlay-common.js
+++ b/telemetry-frontend/public/overlay-common.js
@@ -1,8 +1,12 @@
 let socket;
 
+function overlayHost() {
+  const host = window.location.hostname;
+  return host && host.length > 0 ? host : 'localhost';
+}
+
 function initOverlayWebSocket(onData) {
-  const host = window.location.hostname || 'localhost';
-  const url = window.OVERLAY_WS_URL || `ws://${host}:5221/ws`;
+  const url = window.OVERLAY_WS_URL || `ws://${overlayHost()}:5221/ws`;
   function connect() {
     socket = new WebSocket(url);
     socket.onmessage = (e) => {


### PR DESCRIPTION
## Summary
- ensure overlays connect to localhost when opened from `file://` by defaulting `overlayHost()` to `localhost`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68451527a6f88330b7c4f5f20c847ca0