### PR TITLE
Add placeholder test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,7 @@ Each overlay corresponds to an HTML file in `telemetry-frontend/public/overlays`
 - **Teste Final** – diagnostic overlay combining various widgets.
 
 To open an overlay, start the Electron application and click its name in the menu. Windows can be moved, pinned or closed individually.
+
+## Tests
+
+No automated tests are currently configured for this project. Running `npm test` in `telemetry-frontend` simply prints a placeholder message.

--- a/telemetry-frontend/package.json
+++ b/telemetry-frontend/package.json
@@ -11,7 +11,8 @@
     "dev": "concurrently \"npm run backend\" \"npm run dev:vite\" \"npm run dev:electron\"",
     "build": "vite build",
     "start": "electron .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "echo \"No tests configured\""
   },
   "dependencies": {
     "electron-store": "^10.0.1",


### PR DESCRIPTION
## Summary
- add a `test` script to `telemetry-frontend` that echoes a placeholder
- mention that no automated tests exist in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684527df11c08330b8f2babf7afeb1e8