### PR TITLE
Fix opacity controls and delta bar visuals

### DIFF
--- a/telemetry-frontend/public/overlays/overlay-delta.html
+++ b/telemetry-frontend/public/overlays/overlay-delta.html
@@ -26,13 +26,14 @@
       left: 0;
       width: 450px; /* Largura inicial, pode ser ajustada */
       height: auto; /* Altura automática para se ajustar ao conteúdo */
-      background: rgb(17, 24, 39); /* Cor de fundo escura */
+      background-color: rgba(17, 24, 39, var(--overlay-opacity, 0.98)); /* Cor de fundo com opacidade controlável */
       border: 2px solid #1d4ed8; /* Borda azul */
       border-radius: 0.75rem; /* Cantos arredondados */
       box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5); /* Sombra */
       display: flex;
       flex-direction: column;
       overflow: hidden;
+      filter: contrast(var(--overlay-contrast, 1));
     }
 
     /* --- ESTILOS PARA MODO DE EDIÇÃO GLOBAL --- */
@@ -168,6 +169,15 @@
       position: relative;
       margin-bottom: 0.3rem;
     }
+    .delta-thin-bar {
+      width: 100%;
+      height: 4px;
+      background-color: #1f2937;
+      border-radius: 2px;
+      overflow: hidden;
+      position: relative;
+      margin-bottom: 0.3rem;
+    }
     .bar-fill {
       height: 100%;
       position: absolute;
@@ -247,6 +257,9 @@
       </div>
       <div class="bar">
         <div id="main-delta-bar-fill" class="bar-fill setor-neutro" style="width:0%; left:50%;"></div>
+      </div>
+      <div class="delta-thin-bar">
+        <div id="delta-thin-fill" class="bar-fill setor-neutro" style="width:0%; left:50%;"></div>
       </div>
       <div id="main-delta-text" class="text-gray-300">--</div>
       <div class="sectors-container" id="sectors-container"></div>
@@ -444,15 +457,12 @@
 
     rangeOpacity.oninput = (e) => {
       const opacity = parseFloat(e.target.value);
-      resizableOverlayWrapper.style.opacity = opacity;
+      resizableOverlayWrapper.style.setProperty('--overlay-opacity', opacity);
       saveSetting('opacity', opacity);
     };
     rangeContrast.oninput = (e) => {
-      // Ajustado para usar porcentagem no filtro CSS se for o caso, ou apenas o número
       const contrastValue = parseFloat(e.target.value);
-      resizableOverlayWrapper.style.filter = `contrast(${contrastValue})`; // Se for um número de 0.5 a 2
-      // Se for para ser em porcentagem (50% a 200%):
-      // resizableOverlayWrapper.style.filter = `contrast(${contrastValue * 100}%)`;
+      resizableOverlayWrapper.style.setProperty('--overlay-contrast', contrastValue);
       saveSetting('contrast', contrastValue);
     };
 
@@ -514,11 +524,11 @@
     function loadAllSettings() {
       const opacity = loadSetting('opacity', 0.98);
       rangeOpacity.value = opacity;
-      resizableOverlayWrapper.style.opacity = opacity;
+      resizableOverlayWrapper.style.setProperty('--overlay-opacity', opacity);
 
       const contrast = loadSetting('contrast', 1);
       rangeContrast.value = contrast;
-      resizableOverlayWrapper.style.filter = `contrast(${contrast})`;
+      resizableOverlayWrapper.style.setProperty('--overlay-contrast', contrast);
 
       localPinned = loadSetting('pinned', false);
       updateVisualPinButtonState(localPinned);
@@ -565,6 +575,7 @@
     const gapBehindEl       = document.getElementById('gap-behind');
     const gapFrontEl        = document.getElementById('gap-front');
     const mainDeltaBarFill  = document.getElementById('main-delta-bar-fill');
+    const thinDeltaBarFill  = document.getElementById('delta-thin-fill');
     const mainDeltaText     = document.getElementById('main-delta-text');
     const sectorContainer   = document.getElementById('sectors-container');
     let sectorBarEls  = [];
@@ -604,16 +615,21 @@
       return ['setor-neutro', 'text-yellow-400'];
     }
 
-    function updateMainDeltaBar(value) { 
-      const normalizedValue = Math.max(-1, Math.min(1, value)); 
-      const [bgClass] = getColorClasses(normalizedValue); 
+    function updateMainDeltaBar(value) {
+      const normalizedValue = Math.max(-1, Math.min(1, value));
+      const [bgClass] = getColorClasses(normalizedValue);
       mainDeltaBarFill.className = `bar-fill ${bgClass}`;
-      if (normalizedValue >= 0) { 
+      thinDeltaBarFill.className = `bar-fill ${bgClass}`;
+      if (normalizedValue >= 0) {
         mainDeltaBarFill.style.left = '50%';
-        mainDeltaBarFill.style.width = `${(normalizedValue) * 50}%`; 
-      } else { 
-        mainDeltaBarFill.style.left = `${50 + (normalizedValue * 50)}%`; 
-        mainDeltaBarFill.style.width = `${(-normalizedValue) * 50}%`; 
+        mainDeltaBarFill.style.width = `${(normalizedValue) * 50}%`;
+        thinDeltaBarFill.style.left = '50%';
+        thinDeltaBarFill.style.width = `${(normalizedValue) * 50}%`;
+      } else {
+        mainDeltaBarFill.style.left = `${50 + (normalizedValue * 50)}%`;
+        mainDeltaBarFill.style.width = `${(-normalizedValue) * 50}%`;
+        thinDeltaBarFill.style.left = `${50 + (normalizedValue * 50)}%`;
+        thinDeltaBarFill.style.width = `${(-normalizedValue) * 50}%`;
       }
     }
 
@@ -640,7 +656,7 @@
     // --- Inicialização ---
   document.addEventListener('DOMContentLoaded', async () => {
       loadAllSettings();
-      ensureSectorElements(3);
+      ensureSectorElements(0);
       const { initOverlayWebSocket } = await import('../overlay-common.js');
       initOverlayWebSocket(d => {
           const dados = d.casper || d;

--- a/telemetry-frontend/public/overlays/overlay-inputs.html
+++ b/telemetry-frontend/public/overlays/overlay-inputs.html
@@ -31,7 +31,7 @@
             height:230px; /* Altura inicial ajustada para a marcha */
             min-width:300px; /* Largura mínima */
             min-height:150px; /* Altura mínima ajustada */
-            background:rgb(17,24,39); /* Cor de fundo escura */
+            background-color: rgba(17,24,39,var(--overlay-opacity,0.98)); /* Cor de fundo escura com opacidade controlável */
             border:2px solid #3b82f6; /* Borda azul */
             border-radius:1rem; /* Cantos arredondados */
             box-shadow:0 4px 10px rgba(0,0,0,0.5); /* Sombra */
@@ -39,6 +39,7 @@
             flex-direction:column;
             overflow:hidden;
             -webkit-app-region:drag; /* Permite arrastar a janela no Electron */
+            filter: contrast(var(--overlay-contrast,1));
         }
 
         /* Estilo dos manipuladores de redimensionamento */
@@ -187,9 +188,6 @@
             white-space: nowrap;
             padding: 0 4px;
             text-shadow: 1px 1px 2px rgba(0,0,0,0.7);
-        }
-        .bar-label::before {
-            content: attr(data-label) ' ';
         }
         
         .gear-display {
@@ -486,13 +484,13 @@
 
         rangeOpacity.oninput = async (e) => {
             const opacityValue = parseFloat(e.target.value);
-            resizableOverlayWrapper.style.opacity = opacityValue;
+            resizableOverlayWrapper.style.setProperty('--overlay-opacity', opacityValue);
             saveSetting('opacity', opacityValue);
         };
 
         rangeContrast.oninput = async (e) => {
             const contrastValue = parseFloat(e.target.value);
-            resizableOverlayWrapper.style.filter = `contrast(${contrastValue})`;
+            resizableOverlayWrapper.style.setProperty('--overlay-contrast', contrastValue);
             saveSetting('contrast', contrastValue);
         };
         
@@ -508,20 +506,20 @@
             if (window.electronAPI && window.electronAPI.loadOverlaySettings) {
                 const savedSettings = await window.electronAPI.loadOverlaySettings(OVERLAY_NAME);
                 if (savedSettings) {
-                    if (typeof savedSettings.opacity !== 'undefined') { rangeOpacity.value = savedSettings.opacity; resizableOverlayWrapper.style.opacity = savedSettings.opacity; } 
-                    else { rangeOpacity.value = 0.98; resizableOverlayWrapper.style.opacity = 0.98; }
-                    if (typeof savedSettings.contrast !== 'undefined') { rangeContrast.value = savedSettings.contrast; resizableOverlayWrapper.style.filter = `contrast(${savedSettings.contrast})`; } 
-                    else { rangeContrast.value = 1; resizableOverlayWrapper.style.filter = `contrast(1)`; }
+                    if (typeof savedSettings.opacity !== 'undefined') { rangeOpacity.value = savedSettings.opacity; resizableOverlayWrapper.style.setProperty('--overlay-opacity', savedSettings.opacity); }
+                    else { rangeOpacity.value = 0.98; resizableOverlayWrapper.style.setProperty('--overlay-opacity', 0.98); }
+                    if (typeof savedSettings.contrast !== 'undefined') { rangeContrast.value = savedSettings.contrast; resizableOverlayWrapper.style.setProperty('--overlay-contrast', savedSettings.contrast); }
+                    else { rangeContrast.value = 1; resizableOverlayWrapper.style.setProperty('--overlay-contrast', 1); }
                     if (typeof savedSettings.pinned !== 'undefined') updatePinButtonState(savedSettings.pinned);
                     if (typeof savedSettings.locked !== 'undefined') updateLockButtonState(savedSettings.locked);
                     if (typeof savedSettings.ignoreClicks !== 'undefined') updateClickButtonState(savedSettings.ignoreClicks);
                 } else { 
-                     rangeOpacity.value = 0.98; resizableOverlayWrapper.style.opacity = 0.98;
-                     rangeContrast.value = 1; resizableOverlayWrapper.style.filter = `contrast(1)`;
+                     rangeOpacity.value = 0.98; resizableOverlayWrapper.style.setProperty('--overlay-opacity', 0.98);
+                     rangeContrast.value = 1; resizableOverlayWrapper.style.setProperty('--overlay-contrast', 1);
                 }
-            } else { 
-                rangeOpacity.value = 0.98; resizableOverlayWrapper.style.opacity = 0.98;
-                rangeContrast.value = 1; resizableOverlayWrapper.style.filter = `contrast(1)`;
+            } else {
+                rangeOpacity.value = 0.98; resizableOverlayWrapper.style.setProperty('--overlay-opacity', 0.98);
+                rangeContrast.value = 1; resizableOverlayWrapper.style.setProperty('--overlay-contrast', 1);
             }
             if (window.electronAPI && window.electronAPI.loadOverlayBounds) {
                 const savedBounds = await window.electronAPI.loadOverlayBounds(OVERLAY_NAME);


### PR DESCRIPTION
## Summary
- improve input overlay opacity handling and remove labels
- allow delta overlay opacity/contrast control and add thin delta bar
- let delta overlay support any number of sectors

## Testing
- `npm test`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684530f1b8f883308b68b89d3cadebce