### PR TITLE
Fix delta overlay data and show competitor names

### DIFF
--- a/backend/Models/TelemetryCalculationsOverlay.cs
+++ b/backend/Models/TelemetryCalculationsOverlay.cs
@@ -52,8 +52,11 @@ namespace SuperBackendNR85IA.Calculations
             // Delta de tempo para o carro imediatamente à frente e atrás
             model.TimeDeltaToCarAhead = 0f;
             model.TimeDeltaToCarBehind = 0f;
+            model.CarAheadName = string.Empty;
+            model.CarBehindName = string.Empty;
 
             bool aheadFound = false, behindFound = false;
+            int aheadIdx = -1, behindIdx = -1;
 
             if (model.CarIdxPosition.Length == model.CarIdxF2Time.Length &&
                 model.PlayerCarIdx >= 0 && model.PlayerCarIdx < model.CarIdxPosition.Length)
@@ -70,6 +73,7 @@ namespace SuperBackendNR85IA.Calculations
                         {
                             model.TimeDeltaToCarAhead = val;
                             aheadFound = true;
+                            aheadIdx = i;
                         }
 
                     }
@@ -80,6 +84,7 @@ namespace SuperBackendNR85IA.Calculations
                         {
                             model.TimeDeltaToCarBehind = val;
                             behindFound = true;
+                            behindIdx = i;
                         }
                     }
 
@@ -108,22 +113,24 @@ namespace SuperBackendNR85IA.Calculations
                         float otherPct = model.CarIdxLap[i] + model.CarIdxLapDistPct[i];
                         float myPctAbs = myLap + myPct;
                         float t = GetDeltaTime(myPctAbs, otherPct, trackMeters, speed);
-                        if (Math.Abs(t) > 0.001f)
-                        {
-                            model.TimeDeltaToCarAhead = t;
-                            aheadFound = true;
-                        }
+                            if (Math.Abs(t) > 0.001f)
+                            {
+                                model.TimeDeltaToCarAhead = t;
+                                aheadFound = true;
+                                aheadIdx = i;
+                            }
                     }
                     else if (!behindFound && model.CarIdxPosition[i] == myPos + 1)
                     {
                         float otherPct = model.CarIdxLap[i] + model.CarIdxLapDistPct[i];
                         float myPctAbs = myLap + myPct;
                         float t = GetDeltaTime(myPctAbs, otherPct, trackMeters, speed);
-                        if (Math.Abs(t) > 0.001f)
-                        {
-                            model.TimeDeltaToCarBehind = t;
-                            behindFound = true;
-                        }
+                            if (Math.Abs(t) > 0.001f)
+                            {
+                                model.TimeDeltaToCarBehind = t;
+                                behindFound = true;
+                                behindIdx = i;
+                            }
                     }
 
                     if (aheadFound && behindFound)
@@ -137,6 +144,11 @@ namespace SuperBackendNR85IA.Calculations
                 model.TimeDeltaToCarAhead = model.DistanceAhead / fallbackSpeed;
             if (!behindFound && model.DistanceBehind > 0f && fallbackSpeed > 0f)
                 model.TimeDeltaToCarBehind = model.DistanceBehind / fallbackSpeed;
+
+            if (aheadIdx >= 0 && aheadIdx < model.CarIdxUserNames.Length)
+                model.CarAheadName = model.CarIdxUserNames[aheadIdx];
+            if (behindIdx >= 0 && behindIdx < model.CarIdxUserNames.Length)
+                model.CarBehindName = model.CarIdxUserNames[behindIdx];
 
             model.SectorDeltas = model.LapDeltaToSessionBestSectorTimes ?? Array.Empty<float>();
 

--- a/backend/Models/TelemetryModel.cs
+++ b/backend/Models/TelemetryModel.cs
@@ -123,6 +123,9 @@ namespace SuperBackendNR85IA.Models
         public float DistanceBehind { get; set; }
         public float TimeDeltaToCarAhead { get; set; }
         public float TimeDeltaToCarBehind { get; set; }
+        public string[] CarIdxUserNames { get; set; } = Array.Empty<string>();
+        public string CarAheadName { get; set; } = string.Empty;
+        public string CarBehindName { get; set; } = string.Empty;
 
         public float[] BrakeTemp { get; set; } = Array.Empty<float>();
         public float LfBrakeLinePress { get; set; }

--- a/backend/Services/IRacingTelemetryService.Data.cs
+++ b/backend/Services/IRacingTelemetryService.Data.cs
@@ -406,7 +406,7 @@ namespace SuperBackendNR85IA.Services
                 _lastYaml = t.SessionInfoYaml;
             }
 
-            var (drv, wkd, ses, _) = _cachedYamlData;
+            var (drv, wkd, ses, _, drivers) = _cachedYamlData;
             if (drv != null)
             {
                 t.UserName           = drv.UserName;
@@ -418,6 +418,11 @@ namespace SuperBackendNR85IA.Services
                 t.PlayerCarClassID   = drv.CarClassID;
             }
             t.PlayerCarTeamIncidentCount = GetSdkValue<int>(d, "PlayerCarTeamIncidentCount") ?? 0;
+
+            t.CarIdxUserNames = drivers
+                .OrderBy(di => di.CarIdx)
+                .Select(di => di.UserName)
+                .ToArray();
 
             if (wkd != null)
             {

--- a/backend/Services/IRacingTelemetryService.cs
+++ b/backend/Services/IRacingTelemetryService.cs
@@ -22,7 +22,7 @@ namespace SuperBackendNR85IA.Services
         private readonly SessionYamlParser _yamlParser = new();
 
         private string _lastYaml = string.Empty;
-        private (DriverInfo? Drv, WeekendInfo? Wkd, SessionInfo? Ses,SectorInfo Sec) _cachedYamlData;
+        private (DriverInfo? Drv, WeekendInfo? Wkd, SessionInfo? Ses, SectorInfo Sec, List<DriverInfo> Drivers) _cachedYamlData;
         private int _lastTick = -1;
         private int _lastLap = -1;
         private float _fuelAtLapStart = 0f;

--- a/telemetry-frontend/public/overlays/overlay-delta.html
+++ b/telemetry-frontend/public/overlays/overlay-delta.html
@@ -686,8 +686,14 @@
         mainDeltaText.className = `main-delta-text ${deltaColorClass}`;
         updateMainDeltaBar(deltaValue / 2.0);
 
-        gapFrontEl.textContent = (timeDeltaAhead != null && typeof timeDeltaAhead === 'number') ? `${timeDeltaAhead >= 0 ? '+' : ''}${timeDeltaAhead.toFixed(2)}s` : '--';
-        gapBehindEl.textContent = (timeDeltaBehind != null && typeof timeDeltaBehind === 'number') ? `${timeDeltaBehind >= 0 ? '+' : ''}${timeDeltaBehind.toFixed(2)}s` : '--';
+        const nameFront = dados.carAheadName ?? '';
+        const nameBehind = dados.carBehindName ?? '';
+        gapFrontEl.textContent = (timeDeltaAhead != null && typeof timeDeltaAhead === 'number')
+          ? `${nameFront ? nameFront + ' ' : ''}${timeDeltaAhead >= 0 ? '+' : ''}${timeDeltaAhead.toFixed(2)}s`
+          : (nameFront || '--');
+        gapBehindEl.textContent = (timeDeltaBehind != null && typeof timeDeltaBehind === 'number')
+          ? `${nameBehind ? nameBehind + ' ' : ''}${timeDeltaBehind >= 0 ? '+' : ''}${timeDeltaBehind.toFixed(2)}s`
+          : (nameBehind || '--');
 
         updateSectorBars(sectorDeltas, sectorIsBest);
       }


### PR DESCRIPTION
## Summary
- add fields for driver names and indexes to telemetry model
- parse all driver names from session YAML
- include driver names in telemetry data and overlay calculations
- show the name of the competitor ahead and behind in the delta overlay

## Testing
- `npm test` (prints "No tests configured")
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ddad79988330a1d4e7782c262c32