### PR TITLE
Improve fuel data handling

### DIFF
--- a/backend/Models/TelemetryCalculations.cs
+++ b/backend/Models/TelemetryCalculations.cs
@@ -186,7 +186,7 @@ namespace SuperBackendNR85IA.Calculations
             model.NecessarioFim = (float)GetFuelForTargetLaps(model.LapsRemainingRace, model.ConsumoMedio);
 
             float faltante = model.NecessarioFim - model.FuelLevel;
-            model.RecomendacaoAbastecimento = MathF.Max(0, faltante);
+            model.RecomendacaoAbastecimento = faltante;
         }
 
         public static void UpdateSectorData(ref TelemetryModel model)

--- a/backend/Services/IRacingTelemetryService.Calculations.cs
+++ b/backend/Services/IRacingTelemetryService.Calculations.cs
@@ -63,7 +63,7 @@ namespace SuperBackendNR85IA.Services
                     ? (t.LapsRemainingRace * t.ConsumoMedio) : 0;
                 t.NecessarioFim = fuelNeededForRaceLaps;
                 float faltante = fuelNeededForRaceLaps - t.FuelLevel;
-                t.RecomendacaoAbastecimento = Math.Max(0, faltante);
+                t.RecomendacaoAbastecimento = faltante;
                 t.FuelRemaining = t.FuelLevel;
                 t.FuelEta       = t.LapsRemaining * t.EstLapTime;
                 if (t.FuelLevel <= 0)

--- a/telemetry-frontend/public/overlays/overlay-calculadora.html
+++ b/telemetry-frontend/public/overlays/overlay-calculadora.html
@@ -202,20 +202,24 @@
       const [voltasSimuladas, setVoltasSimuladas] = useState('');
       const [resultado, setResultado]       = useState('');
 
-      // WebSocket para atualizar currentLap e fuelLeft
+      // WebSocket para atualizar dados de telemetria
       useEffect(() => {
-        const socket = new WebSocket("ws://localhost:5221/ws");
-        socket.addEventListener("open", () => console.log("WS FuelCalculator conectado"));
-        socket.addEventListener("message", ({data}) => {
+        const host = window.location.hostname || 'localhost';
+        const url = window.OVERLAY_WS_URL || `ws://${host}:5221/ws`;
+        const socket = new WebSocket(url);
+        socket.addEventListener('open', () => console.log('WS FuelCalculator conectado'));
+        socket.addEventListener('message', ({ data }) => {
           const d = JSON.parse(data);
-          // atualiza volta atual
           setCurrentLap(d.lap ?? 0);
-          // atualiza combustível restante (assume FuelLevelPct é fração 0–1)
-          const pct = d.fuelLevelPct ?? 0;
-          setFuelLeft(pct * tankCapacity);
+
+          const fuel = d.fuelLevel ?? (d.fuelLevelPct ?? 0) * (d.fuelCapacity ?? tankCapacity);
+          setFuelLeft(fuel);
+
+          if (d.fuelCapacity) setTankCapacity(d.fuelCapacity);
+          if (d.consumoMedio) setLapConsumption(d.consumoMedio);
         });
         return () => socket.close();
-      }, [tankCapacity]);
+      }, []);
 
       // Função de cálculo rápido
       const calcular = () => {

--- a/telemetry-frontend/public/overlays/overlay-delta.html
+++ b/telemetry-frontend/public/overlays/overlay-delta.html
@@ -215,6 +215,11 @@
       font-size: 0.875rem;
       font-weight: 600;
     }
+    .best-lap-delta {
+      font-size: 0.875rem;
+      font-weight: 600;
+      text-align: center;
+    }
     /* Cores Tailwind redefinidas para classes CSS */
     .text-blue-400 { color: #60a5fa; }
     .text-purple-400 { color: #c084fc; }
@@ -262,6 +267,7 @@
         <div id="delta-thin-fill" class="bar-fill setor-neutro" style="width:0%; left:50%;"></div>
       </div>
       <div id="main-delta-text" class="text-gray-300">--</div>
+      <div id="best-lap-delta" class="best-lap-delta text-gray-300">--</div>
       <div class="sectors-container" id="sectors-container"></div>
     </div>
   </div>
@@ -579,6 +585,7 @@
     const mainDeltaBarFill  = document.getElementById('main-delta-bar-fill');
     const thinDeltaBarFill  = document.getElementById('delta-thin-fill');
     const mainDeltaText     = document.getElementById('main-delta-text');
+    const bestLapDeltaEl    = document.getElementById('best-lap-delta');
     const sectorContainer   = document.getElementById('sectors-container');
     let sectorBarEls  = [];
     let sectorTimeEls = [];
@@ -681,10 +688,21 @@
             return (typeof current === 'number' && typeof best === 'number' && Math.abs(current - best) < 0.0001);
         });
 
+        const bestLapDelta = dados.lapDeltaToDriverBestLap;
+
         mainDeltaText.textContent = `${deltaValue >= 0 ? '+' : ''}${deltaValue.toFixed(3)}s`;
         const [_, deltaColorClass] = getColorClasses(deltaValue);
         mainDeltaText.className = `main-delta-text ${deltaColorClass}`;
         updateMainDeltaBar(deltaValue / 2.0);
+
+        if (bestLapDelta != null && !isNaN(bestLapDelta)) {
+          const [, bestColorClass] = getColorClasses(bestLapDelta);
+          bestLapDeltaEl.textContent = `${bestLapDelta >= 0 ? '+' : ''}${bestLapDelta.toFixed(3)}s`;
+          bestLapDeltaEl.className = `best-lap-delta ${bestColorClass}`;
+        } else {
+          bestLapDeltaEl.textContent = '--';
+          bestLapDeltaEl.className = 'best-lap-delta text-gray-300';
+        }
 
         const nameFront = dados.carAheadName ?? '';
         const nameBehind = dados.carBehindName ?? '';


### PR DESCRIPTION
## Summary
- adjust fuel calculation in backend to allow negative refueling recommendation
- expose car fuel data for calculator overlay
- use WS URL helper in calculator overlay and set lap consumption from backend
- restore best lap delta display in delta overlay

## Testing
- `npm test` *(fails: package.json missing)*
- `dotnet build backend/SuperBackendNR85IA.csproj -clp:ErrorsOnly` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e4c309dc8330ad0a922f2cfc609e