### PR TITLE
Fix Delta and Fuel overlay behavior

### DIFF
--- a/telemetry-frontend/public/overlays/overlay-delta.html
+++ b/telemetry-frontend/public/overlays/overlay-delta.html
@@ -26,6 +26,8 @@
       left: 0;
       width: 450px; /* Largura inicial, pode ser ajustada */
       height: auto; /* Altura automática para se ajustar ao conteúdo */
+      min-width: 200px;
+      min-height: 150px;
       background-color: rgba(17, 24, 39, var(--overlay-opacity, 0.98)); /* Cor de fundo com opacidade controlável */
       border: 2px solid #1d4ed8; /* Borda azul */
       border-radius: 0.75rem; /* Cantos arredondados */
@@ -185,7 +187,7 @@
       transition: width 0.1s ease-out, left 0.1s ease-out;
     }
     #main-delta-text {
-      font-size: 1.5rem;
+      font-size: 2rem;
       font-weight: 700;
       margin-bottom: 0.5rem;
     }
@@ -216,7 +218,7 @@
       font-weight: 600;
     }
     .best-lap-delta {
-      font-size: 0.875rem;
+      font-size: 1rem;
       font-weight: 600;
       text-align: center;
     }

--- a/telemetry-frontend/public/overlays/overlay-tanque.html
+++ b/telemetry-frontend/public/overlays/overlay-tanque.html
@@ -682,24 +682,30 @@
             voltasRestantesAtualValor.classList.add('text-blue-400');
         }
 
-        // Necessário para o Fim
-        necessarioFimValor.textContent = `${(model.necessarioFim ?? 0).toFixed(1)}L`; // necessarioFim
+        // Necessário para o Fim (nunca negativo)
+        const necessario = Math.max(0, model.necessarioFim ?? 0);
+        necessarioFimValor.textContent = `${necessario.toFixed(1)}L`;
 
-        // Status do Combustível
-        const status = model.fuelStatus ?? {};
-        statusValor.textContent = status.text ?? '--';
-        // Remove todas as classes de status antes de adicionar a nova
-        statusValor.className = 'text-lg font-bold'; // Reseta para classes base
-        const statusClass = status.class;
-        if (statusClass) {
-            statusValor.classList.add(statusClass);
+        // Status do Combustível baseado nas voltas restantes
+        const lapsDisplay = lapsForWarning;
+        let statusText, statusClass;
+        if (lapsDisplay <= 1) {
+            statusText = 'PERIGO';
+            statusClass = 'status-danger';
+        } else if (lapsDisplay <= 3) {
+            statusText = 'ALERTA';
+            statusClass = 'status-warning';
         } else {
-            statusValor.classList.add('status-ok'); // Fallback
+            statusText = 'OK';
+            statusClass = 'status-ok';
         }
+        statusValor.textContent = `${statusText} (${lapsDisplay})`;
+        statusValor.className = `text-lg font-bold ${statusClass}`;
 
-        // Recomendação de Abastecimento
-        const rec = model.recomendacaoAbastecimento ?? model.RecomendacaoAbastecimento ?? 0; // recomendacaoAbastecimento
-        recomendacaoAbastecimentoValor.textContent = `${rec >= 0 ? '+' : ''}${rec.toFixed(1)}L`;
+        // Recomendação de Abastecimento (nunca negativa)
+        const recRaw = model.recomendacaoAbastecimento ?? model.RecomendacaoAbastecimento ?? 0;
+        const rec = Math.max(0, recRaw);
+        recomendacaoAbastecimentoValor.textContent = `+${rec.toFixed(1)}L`;
         recomendacaoAbastecimentoValor.className = `text-lg font-bold ${rec > 0 ? 'text-blue-500' : 'text-green-600'}`;
     }
 


### PR DESCRIPTION
## Summary
- tweak delta overlay sizing defaults
- enlarge delta text for readability
- clamp negative numbers in fuel overlay and drive status directly from laps left

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845f750e9c48330b8b9dbc598b430a0