### PR TITLE
Create classification overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ npm run dev
 
 The `dev` script launches the backend, the Vite development server and Electron simultaneously. When Electron starts, a menu will appear listing the available overlays.
 
+## Session YAML Exposure
+
+Every WebSocket payload includes the raw `sessionInfoYaml` string from iRacing **and** several parsed objects derived from that YAML. The backend exposes these objects directly so overlays do not need to parse the YAML themselves. Available fields are:
+
+- `yamlPlayerDriver` – information about the current player driver
+- `yamlWeekendInfo` – track and weather details for the event
+- `yamlSessionInfo` – data for the current session, including lap counts
+- `yamlSectorInfo` – sector configuration and best sector times
+- `yamlDrivers` – an array with basic info on all drivers
+
+A sample payload is available in `ws/messages/overlay_message.json` and the latest YAML dump is written to `yamls/input_current.yaml` whenever the backend updates.
+
 ## Overlays
 
 Each overlay corresponds to an HTML file in `telemetry-frontend/public/overlays` and can be opened from the Electron menu. A brief description of each overlay follows:
@@ -38,6 +50,7 @@ Each overlay corresponds to an HTML file in `telemetry-frontend/public/overlays`
 - **Tires & Freio** – tire temperatures and brake information with ABS/TC.
 - **Tires Garage** – garage view of tire and brake data.
 - **Standings** – table of race standings and session info.
+- **Classificação** – shows full race classification with lap gaps.
 - **Calculadora** – another compact fuel calculator.
 - **Base** – basic classification template overlay.
 - **Teste Final** – diagnostic overlay combining various widgets.

--- a/backend/Models/TelemetryCalculations.cs
+++ b/backend/Models/TelemetryCalculations.cs
@@ -254,6 +254,8 @@ namespace SuperBackendNR85IA.Calculations
         {
             foreach (var prop in obj.GetType().GetProperties())
             {
+                if (prop.GetIndexParameters().Length > 0)
+                    continue; // skip indexer properties like List<T>.Item
                 if (prop.PropertyType == typeof(float))
                 {
                     float val = (float)(prop.GetValue(obj) ?? 0f);

--- a/backend/Models/TelemetryModel.cs
+++ b/backend/Models/TelemetryModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace SuperBackendNR85IA.Models
 {
@@ -216,6 +217,12 @@ namespace SuperBackendNR85IA.Models
         public float ChanceOfRain { get; set; }
         public int IncidentLimit { get; set; }
         public float TrackAirTemp { get; set; }
+        // Parsed YAML objects
+        public WeekendInfo? YamlWeekendInfo { get; set; }
+        public SessionInfo? YamlSessionInfo { get; set; }
+        public SectorInfo? YamlSectorInfo { get; set; }
+        public DriverInfo? YamlPlayerDriver { get; set; }
+        public List<DriverInfo> YamlDrivers { get; set; } = new();
         public string SessionInfoYaml { get; set; } = string.Empty;
 
         public static string FormatTime(float seconds)

--- a/backend/Services/IRacingTelemetryService.Data.cs
+++ b/backend/Services/IRacingTelemetryService.Data.cs
@@ -408,7 +408,12 @@ namespace SuperBackendNR85IA.Services
                 _lastYaml = t.SessionInfoYaml;
             }
 
-            var (drv, wkd, ses, _, drivers) = _cachedYamlData;
+            var (drv, wkd, ses, sec, drivers) = _cachedYamlData;
+            t.YamlPlayerDriver = drv;
+            t.YamlWeekendInfo  = wkd;
+            t.YamlSessionInfo  = ses;
+            t.YamlSectorInfo   = sec;
+            t.YamlDrivers      = drivers;
             if (drv != null)
             {
                 t.UserName           = drv.UserName;

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,3 +1,6 @@
 # TODO
 
-- Implementar inclusão de SessionInfoYaml nas mensagens WebSocket para overlays
+- ~~Implementar inclusão de SessionInfoYaml nas mensagens WebSocket para overlays~~
+  - **Concluído**: o backend envia agora a propriedade `sessionInfoYaml` em cada
+    mensagem WebSocket para que novas overlays possam aproveitar todos os dados
+    do iRacing.

--- a/telemetry-frontend/public/menu.html
+++ b/telemetry-frontend/public/menu.html
@@ -28,6 +28,7 @@
   <nav class="sidebar">
    <button onclick="abrir('overlay-testefinal.html','testefinal')"><i class="fas fa-list"></i> Teste Final</button>
    <button onclick="abrir('overlay-standings.html','standings')"><i class="fas fa-trophy"></i> Standings</button>
+   <button onclick="abrir('overlay-classificacao.html','classificacao')"><i class="fas fa-flag-checkered"></i> Classificação</button>
    <button onclick="abrir('overlay-inputs.html','inputs')"><i class="fas fa-sliders-h"></i> Inputs</button>
    <button onclick="abrir('overlay-calculadora.html','calculadora')"><i class="fas fa-gas-pump"></i> Calculadora</button>
    <button onclick="abrir('overlay-delta.html','delta')"><i class="fas fa-stopwatch"></i> Delta</button>

--- a/telemetry-frontend/public/overlays/overlay-classificacao.html
+++ b/telemetry-frontend/public/overlays/overlay-classificacao.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Classificação - NR85 IA</title>
+  <script src="https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/dist/js-yaml.min.js"></script>
+  <style>
+    html,body{margin:0;padding:0;height:100%;font-family:'Poppins',sans-serif;background:rgba(15,23,42,0.9);color:#e2e8f0;overflow:hidden;font-size:0.85rem;}
+    table{width:100%;border-collapse:collapse;}
+    th,td{padding:4px 6px;}
+    thead{background:#2563eb;color:#fff;position:sticky;top:0;}
+    tbody tr:nth-child(even){background:rgba(30,41,59,0.6);}
+    tbody tr:nth-child(odd){background:rgba(30,41,59,0.4);}
+    .pit-timer{border:1px solid #facc15;padding:0 4px;border-radius:3px;color:#facc15;}
+  </style>
+</head>
+<body>
+<table>
+  <thead>
+    <tr>
+      <th>Pos</th>
+      <th>#</th>
+      <th>Marca</th>
+      <th>SR</th>
+      <th>IR</th>
+      <th>Piloto</th>
+      <th>Melhor</th>
+      <th>Última</th>
+      <th>Líder</th>
+      <th>Gap</th>
+      <th>Pit</th>
+      <th>Pneu</th>
+    </tr>
+  </thead>
+  <tbody id="tbody"></tbody>
+</table>
+<script type="module">
+import { initOverlayWebSocket } from '../overlay-common.js';
+let lastYaml='';
+let parsed={};
+const pitStart={};
+function fmtTime(s){if(typeof s!=='number'||!isFinite(s)||s<=0)return'--';const m=Math.floor(s/60);const sec=Math.floor(s%60);return`${m.toString().padStart(2,'0')}:${sec.toString().padStart(2,'0')}`;}
+function brandFromPath(path){if(!path)return'';let b=path.split('/').pop();b=b.split('_')[0];return b;}
+function update(data){data={...data,...(data.session||{}),...(data.vehicle||{})};if(data.sessionInfoYaml&&data.sessionInfoYaml!==lastYaml){parsed=jsyaml.load(data.sessionInfoYaml)||{};lastYaml=data.sessionInfoYaml;}
+const drivers=parsed?.DriverInfo?.Drivers||[];
+const session=(parsed?.SessionInfo?.Sessions||[]).find(s=>s.SessionNum===data.sessionNum)||{};
+const results=(session?.ResultsPositions||[]).slice().sort((a,b)=>a.Position-b.Position);
+const f2=data.carIdxF2Time||[];
+const onPit=data.carIdxOnPitRoad||[];
+const tbody=document.getElementById('tbody');
+tbody.innerHTML='';
+if(results.length===0)return;
+const leaderIdx=results[0].CarIdx;
+const leaderF2=f2[leaderIdx]??0;
+for(let i=0;i<results.length;i++){
+ const r=results[i];
+ const drv=drivers.find(d=>d.CarIdx===r.CarIdx)||{};
+ const tr=document.createElement('tr');
+ const thisF2=f2[r.CarIdx]??0;
+ const aheadF2=i>0?f2[results[i-1].CarIdx]??thisF2:thisF2;
+ const diffLeader=i===0?'---':(thisF2-leaderF2).toFixed(1);
+ const gapAhead=i===0?'---':(thisF2-aheadF2).toFixed(1);
+ let pitCell='';
+ if(onPit[r.CarIdx]){pitStart[r.CarIdx]=pitStart[r.CarIdx]??data.sessionTime;pitCell=`<span class="pit-timer">${fmtTime(data.sessionTime-pitStart[r.CarIdx])}</span>`;} else {delete pitStart[r.CarIdx];}
+ tr.innerHTML=`<td>${r.Position}</td><td>${drv.CarNumber||''}</td><td>${brandFromPath(drv.CarPath)}</td><td>${drv.LicString||''}</td><td>${drv.IRating||''}</td><td>${drv.UserName||''}</td><td>${fmtTime(r.FastestTime)}</td><td>${fmtTime(r.LastTime)}</td><td>${diffLeader}</td><td>${gapAhead}</td><td>${pitCell}</td><td>${drv.CarSetup?.Tires?.CompoundName||''}</td>`;
+ tbody.appendChild(tr);
+}
+}
+initOverlayWebSocket(update);
+</script>
+</body>
+</html>

--- a/ws/messages/overlay_message.json
+++ b/ws/messages/overlay_message.json
@@ -1,3 +1,21 @@
 {
-  "sessionInfoYaml": ""
+  "sessionInfoYaml": "",
+  "yamlPlayerDriver": {
+    "carIdx": 0,
+    "userName": "Driver One"
+  },
+  "yamlWeekendInfo": {
+    "trackDisplayName": "Interlagos",
+    "trackConfigName": "Grand Prix"
+  },
+  "yamlSessionInfo": {
+    "sessionNum": 0,
+    "sessionType": "Practice"
+  },
+  "yamlSectorInfo": {
+    "sectorCount": 3
+  },
+  "yamlDrivers": [
+    { "carIdx": 0, "userName": "Driver One" }
+  ]
 }


### PR DESCRIPTION
## Summary
- add new overlay to show race classification with YAML data
- link the overlay from the menu
- document the overlay in README
- expose parsed YAML objects in TelemetryModel for overlays
- sanitize list properties to avoid backend crash

## Testing
- `npm test --silent --prefix telemetry-frontend`


------
https://chatgpt.com/codex/tasks/task_e_68461a75d97c8330ba944ff403db87d0