### PR TITLE
Expand driver info for overlays

### DIFF
--- a/backend/Models/TelemetryModel.cs
+++ b/backend/Models/TelemetryModel.cs
@@ -125,6 +125,12 @@ namespace SuperBackendNR85IA.Models
         public float TimeDeltaToCarAhead { get; set; }
         public float TimeDeltaToCarBehind { get; set; }
         public string[] CarIdxUserNames { get; set; } = Array.Empty<string>();
+        public string[] CarIdxCarNumbers { get; set; } = Array.Empty<string>();
+        public string[] CarIdxTeamNames { get; set; } = Array.Empty<string>();
+        public int[] CarIdxIRatings { get; set; } = Array.Empty<int>();
+        public string[] CarIdxLicStrings { get; set; } = Array.Empty<string>();
+        public int[] CarIdxCarClassIds { get; set; } = Array.Empty<int>();
+        public string[] CarIdxCarClassShortNames { get; set; } = Array.Empty<string>();
         public string CarAheadName { get; set; } = string.Empty;
         public string CarBehindName { get; set; } = string.Empty;
 

--- a/backend/Services/IRacingTelemetryService.Data.cs
+++ b/backend/Services/IRacingTelemetryService.Data.cs
@@ -426,10 +426,14 @@ namespace SuperBackendNR85IA.Services
             }
             t.PlayerCarTeamIncidentCount = GetSdkValue<int>(d, "PlayerCarTeamIncidentCount") ?? 0;
 
-            t.CarIdxUserNames = drivers
-                .OrderBy(di => di.CarIdx)
-                .Select(di => di.UserName)
-                .ToArray();
+            var orderedDrivers = drivers.OrderBy(di => di.CarIdx).ToList();
+            t.CarIdxUserNames = orderedDrivers.Select(di => di.UserName).ToArray();
+            t.CarIdxCarNumbers = orderedDrivers.Select(di => di.CarNumber).ToArray();
+            t.CarIdxTeamNames  = orderedDrivers.Select(di => di.TeamName).ToArray();
+            t.CarIdxIRatings   = orderedDrivers.Select(di => di.IRating).ToArray();
+            t.CarIdxLicStrings = orderedDrivers.Select(di => di.LicString).ToArray();
+            t.CarIdxCarClassIds = orderedDrivers.Select(di => di.CarClassID).ToArray();
+            t.CarIdxCarClassShortNames = orderedDrivers.Select(di => di.CarClassShortName).ToArray();
 
             if (wkd != null)
             {

--- a/backend/Services/SessionYamlParser.cs
+++ b/backend/Services/SessionYamlParser.cs
@@ -68,8 +68,20 @@ namespace SuperBackendNR85IA.Services
             {
                 list.Add(new DriverInfo
                 {
-                    CarIdx   = GetInt(child, "CarIdx"),
-                    UserName = GetStr(child, "UserName")
+                    CarIdx            = GetInt(child, "CarIdx"),
+                    UserName          = GetStr(child, "UserName"),
+                    TeamName          = GetStr(child, "TeamName"),
+                    UserID            = GetInt(child, "UserID"),
+                    TeamID            = GetInt(child, "TeamID"),
+                    CarNumber         = GetStr(child, "CarNumberRaw"),
+                    IRating           = GetInt(child, "IRating"),
+                    LicString         = GetStr(child, "LicString"),
+                    LicLevel          = GetInt(child, "LicLevel"),
+                    LicSubLevel       = GetInt(child, "LicSubLevel"),
+                    CarPath           = GetStr(child, "CarPath"),
+                    CarClassID        = GetInt(child, "CarClassID"),
+                    CarClassShortName = GetStr(child, "CarClassShortName"),
+                    CarClassRelSpeed  = GetFloat(child, "CarClassRelSpeed")
                 });
             }
 


### PR DESCRIPTION
## Summary
- expose full driver details for all cars
- send arrays with car numbers, team names, ratings, licenses and car classes
- parse complete driver info from the session YAML

## Testing
- `npm test` *(fails: No tests configured)*
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68462686b1188330bdc3bfc0c1655df5