### PR TITLE
Expand driver info for overlays

### DIFF
--- a/backend/Models/TelemetryModel.cs
+++ b/backend/Models/TelemetryModel.cs
@@ -125,6 +125,12 @@ namespace SuperBackendNR85IA.Models
         public float TimeDeltaToCarAhead { get; set; }
         public float TimeDeltaToCarBehind { get; set; }
         public string[] CarIdxUserNames { get; set; } = Array.Empty<string>();
+        public string[] CarIdxCarNumbers { get; set; } = Array.Empty<string>();
+        public string[] CarIdxTeamNames { get; set; } = Array.Empty<string>();
+        public int[] CarIdxIRatings { get; set; } = Array.Empty<int>();
+        public string[] CarIdxLicStrings { get; set; } = Array.Empty<string>();
+        public int[] CarIdxCarClassIds { get; set; } = Array.Empty<int>();
+        public string[] CarIdxCarClassShortNames { get; set; } = Array.Empty<string>();
         public string CarAheadName { get; set; } = string.Empty;
         public string CarBehindName { get; set; } = string.Empty;
 

--- a/backend/Services/IRacingTelemetryService.Data.cs
+++ b/backend/Services/IRacingTelemetryService.Data.cs
@@ -426,10 +426,14 @@ namespace SuperBackendNR85IA.Services
             }
             t.PlayerCarTeamIncidentCount = GetSdkValue<int>(d, "PlayerCarTeamIncidentCount") ?? 0;
 
-            t.CarIdxUserNames = drivers
-                .OrderBy(di => di.CarIdx)
-                .Select(di => di.UserName)
-                .ToArray();
+            var orderedDrivers = drivers.OrderBy(di => di.CarIdx).ToList();
+            t.CarIdxUserNames = orderedDrivers.Select(di => di.UserName).ToArray();
+            t.CarIdxCarNumbers = orderedDrivers.Select(di => di.CarNumber).ToArray();
+            t.CarIdxTeamNames  = orderedDrivers.Select(di => di.TeamName).ToArray();
+            t.CarIdxIRatings   = orderedDrivers.Select(di => di.IRating).ToArray();
+            t.CarIdxLicStrings = orderedDrivers.Select(di => di.LicString).ToArray();
+            t.CarIdxCarClassIds = orderedDrivers.Select(di => di.CarClassID).ToArray();
+            t.CarIdxCarClassShortNames = orderedDrivers.Select(di => di.CarClassShortName).ToArray();
 
             if (wkd != null)
             {

--- a/backend/Services/SessionYamlParser.cs
+++ b/backend/Services/SessionYamlParser.cs
@@ -68,8 +68,20 @@ namespace SuperBackendNR85IA.Services
             {
                 list.Add(new DriverInfo
                 {
-                    CarIdx   = GetInt(child, "CarIdx"),
-                    UserName = GetStr(child, "UserName")
+                    CarIdx            = GetInt(child, "CarIdx"),
+                    UserName          = GetStr(child, "UserName"),
+                    TeamName          = GetStr(child, "TeamName"),
+                    UserID            = GetInt(child, "UserID"),
+                    TeamID            = GetInt(child, "TeamID"),
+                    CarNumber         = GetStr(child, "CarNumberRaw"),
+                    IRating           = GetInt(child, "IRating"),
+                    LicString         = GetStr(child, "LicString"),
+                    LicLevel          = GetInt(child, "LicLevel"),
+                    LicSubLevel       = GetInt(child, "LicSubLevel"),
+                    CarPath           = GetStr(child, "CarPath"),
+                    CarClassID        = GetInt(child, "CarClassID"),
+                    CarClassShortName = GetStr(child, "CarClassShortName"),
+                    CarClassRelSpeed  = GetFloat(child, "CarClassRelSpeed")
                 });
             }
 

--- a/telemetry-frontend/public/overlays/overlay-standings.html
+++ b/telemetry-frontend/public/overlays/overlay-standings.html
@@ -133,8 +133,48 @@ function updateOverlay(data) {
     if (lap !== undefined) {
         document.getElementById('lapsCompleted').textContent = lap;
     }
-    
-    // Adicione mais campos conforme necessário, verificando sempre se existem
+
+    updateStandingsTable(data);
+}
+
+function updateStandingsTable(d) {
+    const body = document.getElementById('standings-body');
+    if (!body) return;
+
+    const posArr    = d.carIdxPosition    || [];
+    const numArr    = d.carIdxCarNumbers  || [];
+    const nameArr   = d.carIdxUserNames   || [];
+    const classArr  = d.carIdxCarClassShortNames || [];
+    const lapArr    = d.carIdxLap         || [];
+    const lastLap   = d.carIdxLastLapTime || [];
+
+    const cars = [];
+    for (let i = 0; i < posArr.length; i++) {
+        if (posArr[i] <= 0) continue;
+        cars.push({
+            pos: posArr[i],
+            num: numArr[i] || '',
+            name: nameArr[i] || '',
+            cls: classArr[i] || '',
+            lap: lapArr[i] || 0,
+            last: lastLap[i] || 0
+        });
+    }
+
+    cars.sort((a,b) => a.pos - b.pos);
+
+    body.innerHTML = '';
+    for (const c of cars) {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+            <td class="position">${c.pos}</td>
+            <td class="number">${c.num}</td>
+            <td>${c.name}</td>
+            <td class="car">${c.cls}</td>
+            <td>${c.lap}</td>
+            <td>${c.last.toFixed ? c.last.toFixed(2) : c.last}</td>`;
+        body.appendChild(tr);
+    }
 }
 
 // Inicia a conexão quando a página carrega

--- a/telemetry-frontend/public/overlays/overlay-tiresandbrakes.html
+++ b/telemetry-frontend/public/overlays/overlay-tiresandbrakes.html
@@ -584,6 +584,23 @@
     ];
 
     function handleData(d) {
+        if (!Array.isArray(d.tireTemps)) {
+            d.tireTemps = [d.lfTempCm, d.rfTempCm, d.lrTempCm, d.rrTempCm];
+        }
+        if (!Array.isArray(d.tirePressures)) {
+            d.tirePressures = [d.lfPress, d.rfPress, d.lrPress, d.rrPress];
+        }
+        if (!Array.isArray(d.tireBrakes)) {
+            d.tireBrakes = (d.brakeTemp || []).slice(0,4);
+        }
+        if (!Array.isArray(d.tireAssistOn)) {
+            const on = (d.dcAbs ?? 0) > 0;
+            d.tireAssistOn = [on,on,on,on];
+        }
+        if (!Array.isArray(d.tireCompound)) {
+            d.tireCompound = ['U','U','U','U'];
+        }
+
         tireMap.forEach(({id, idx}) => {
             const el = document.getElementById(id);
             if (!el) return;

--- a/telemetry-frontend/public/overlays/overlay-tiresgarage.html
+++ b/telemetry-frontend/public/overlays/overlay-tiresgarage.html
@@ -718,14 +718,36 @@
 
 
     function handleData(d) {
-        const tires = d.tyres || d.tires;
-        if (tires) {
-            tireMap.forEach(({id, iRacingKey}) => {
-                if (tires[iRacingKey]) {
-                    updateTireUI(id, tires[iRacingKey]);
+        let tires = d.tyres || d.tires;
+        if (!tires) {
+            tires = {
+                frontLeft:  {
+                    wear:{left:(d.lfWear?.[0]||0),middle:(d.lfWear?.[1]||0),right:(d.lfWear?.[2]||0)},
+                    temp:{left:d.lfTempCl||0,middle:d.lfTempCm||0,right:d.lfTempCr||0},
+                    pressure:d.lfPress||0, compound:'U'
+                },
+                frontRight: {
+                    wear:{left:(d.rfWear?.[0]||0),middle:(d.rfWear?.[1]||0),right:(d.rfWear?.[2]||0)},
+                    temp:{left:d.rfTempCl||0,middle:d.rfTempCm||0,right:d.rfTempCr||0},
+                    pressure:d.rfPress||0, compound:'U'
+                },
+                rearLeft:   {
+                    wear:{left:(d.lrWear?.[0]||0),middle:(d.lrWear?.[1]||0),right:(d.lrWear?.[2]||0)},
+                    temp:{left:d.lrTempCl||0,middle:d.lrTempCm||0,right:d.lrTempCr||0},
+                    pressure:d.lrPress||0, compound:'U'
+                },
+                rearRight:  {
+                    wear:{left:(d.rrWear?.[0]||0),middle:(d.rrWear?.[1]||0),right:(d.rrWear?.[2]||0)},
+                    temp:{left:d.rrTempCl||0,middle:d.rrTempCm||0,right:d.rrTempCr||0},
+                    pressure:d.rrPress||0, compound:'U'
                 }
-            });
+            };
         }
+        tireMap.forEach(({id, iRacingKey}) => {
+            if (tires[iRacingKey]) {
+                updateTireUI(id, tires[iRacingKey]);
+            }
+        });
     }
 
     // --- Inicialização ---


### PR DESCRIPTION
## Summary
- expose full driver details for all cars
- send arrays with car numbers, team names, ratings, licenses and car classes
- parse complete driver info from the session YAML
- render standings table using these arrays
- derive tire data from flat fields when arrays are missing so tire overlays update

## Testing
- `npm test` *(passes: no tests configured)*
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68462686b1188330bdc3bfc0c1655df5