### PR TITLE
Improve overlay data rendering

### DIFF
--- a/telemetry-frontend/public/overlays/overlay-classificacao.html
+++ b/telemetry-frontend/public/overlays/overlay-classificacao.html
@@ -21,12 +21,11 @@
     <tr>
       <th>Pos</th>
       <th>#</th>
-      <th>Marca</th>
       <th>SR</th>
       <th>IR</th>
       <th>Piloto</th>
-      <th>Melhor</th>
       <th>Última</th>
+      <th>Voltas</th>
       <th>Líder</th>
       <th>Gap</th>
       <th>Pit</th>
@@ -47,23 +46,26 @@ function update(data){
  const srs=data.carIdxLicStrings||[];
  const irs=data.carIdxIRatings||[];
  const last=data.carIdxLastLapTime||[];
+ const laps=data.carIdxLap||[];
  const f2=data.carIdxF2Time||[];
  const onPit=data.carIdxOnPitRoad||[];
  const compounds=data.carIdxTireCompounds||[];
  const tbody=document.getElementById('tbody');
  tbody.innerHTML='';
  const cars=[];
- for(let i=0;i<pos.length;i++){if(pos[i]<=0)continue;cars.push({idx:i,pos:pos[i],num:nums[i]||'',name:names[i]||'',sr:srs[i]||'',ir:irs[i]||'',last:last[i]||0,gap:f2[i]||0,pit:onPit[i],compound:compounds[i]||''});}
+ for(let i=0;i<pos.length;i++){if(pos[i]<=0)continue;cars.push({idx:i,pos:pos[i],num:nums[i]||'',name:names[i]||'',sr:srs[i]||'',ir:irs[i]||'',last:last[i]||0,lap:laps[i]||0,gap:f2[i]||0,pit:onPit[i],compound:compounds[i]||''});}
  cars.sort((a,b)=>a.pos-b.pos);
  const leaderGap=cars.length>0?cars[0].gap:0;
  for(let i=0;i<cars.length;i++){
   const c=cars[i];
-  const gapL=i===0?'---':(c.gap-leaderGap).toFixed(1);
-  const gapA=i===0?'---':(c.gap-cars[i-1].gap).toFixed(1);
+  const diffLeader=c.gap-leaderGap;
+  const diffAhead=c.gap-(i>0?cars[i-1].gap:c.gap);
+  const gapL=i===0?'---':(Math.abs(diffLeader)>60?'--':diffLeader.toFixed(1));
+  const gapA=i===0?'---':(Math.abs(diffAhead)>60?'--':diffAhead.toFixed(1));
   let pitCell='';
   if(c.pit){pitStart[c.idx]=pitStart[c.idx]??data.sessionTime;pitCell=`<span class="pit-timer">${fmtTime(data.sessionTime-pitStart[c.idx])}</span>`;} else {delete pitStart[c.idx];}
   const tr=document.createElement('tr');
-  tr.innerHTML=`<td>${c.pos}</td><td>${c.num}</td><td>${c.sr}</td><td>${c.ir}</td><td>${c.name}</td><td>${fmtTime(c.last)}</td><td>${gapL}</td><td>${gapA}</td><td>${pitCell}</td><td>${c.compound}</td>`;
+  tr.innerHTML=`<td>${c.pos}</td><td>${c.num}</td><td>${c.sr}</td><td>${c.ir}</td><td>${c.name}</td><td>${fmtTime(c.last)}</td><td>${c.lap}</td><td>${gapL}</td><td>${gapA}</td><td>${pitCell}</td><td>${c.compound}</td>`;
   tbody.appendChild(tr);
  }
 }

--- a/telemetry-frontend/public/overlays/overlay-relative.html
+++ b/telemetry-frontend/public/overlays/overlay-relative.html
@@ -267,6 +267,7 @@
         .driver-row span.car-name-class { width: 7.5rem; text-align: left; font-size: 0.7rem; justify-content: flex-start;} 
         .driver-row span.driver-name { flex-grow: 1; margin: 0 0.3rem; text-align: left; min-width: 70px; justify-content: flex-start;} 
         .driver-row div.rating-container { width: 6rem; text-align: center; display: flex; justify-content: center; align-items: center; } 
+        .driver-row span.lap-count { width: 3rem; text-align: right; font-size: 0.7rem; justify-content: flex-end; }
         .driver-row span.gap-time { width: 4rem; text-align: right; font-size: 0.7rem; justify-content: flex-end;}
         .driver-row span.last-lap-time { width: 4.5rem; text-align: right; font-size: 0.7rem; justify-content: flex-end; color: #a1a1aa;}
 
@@ -618,8 +619,10 @@ function renderRelative(data) {
     if (playerInSortedList && car.idx !== playerCarIdx) {
         if (playerInSortedList.lap === car.lap && car.f2Time !== undefined && car.f2Time !== -1) {
             const timeDiff = car.f2Time;
-            gapText = (timeDiff > 0 ? '+' : '') + timeDiff.toFixed(2);
-            gapClass = timeDiff > 0 ? 'gap-positive' : (timeDiff < 0 ? 'gap-negative' : 'gap-neutral');
+            if (Math.abs(timeDiff) <= 60) {
+                gapText = (timeDiff > 0 ? '+' : '') + timeDiff.toFixed(2);
+                gapClass = timeDiff > 0 ? 'gap-positive' : (timeDiff < 0 ? 'gap-negative' : 'gap-neutral');
+            }
         } else if (playerInSortedList.lap !== undefined && car.lap !== undefined) {
             const lapDiff = car.lap - playerInSortedList.lap;
             if (lapDiff !== 0) {
@@ -650,6 +653,7 @@ function renderRelative(data) {
         <span class="sr-badge badge ${getSRClass(car.lic)}">${srBadgeLetter}</span>
         <span class="irating-badge badge">${iRatingDisplay}</span>
       </div>
+      <span class="lap-count">${car.lap ?? '--'}</span>
       <span class="gap-time ${gapClass}">${gapText}</span>
       <span class="last-lap-time">${fmtTimeSimple(car.lastLapTime)}</span>
     `;

--- a/telemetry-frontend/public/overlays/overlay-tiresgarage.html
+++ b/telemetry-frontend/public/overlays/overlay-tiresgarage.html
@@ -718,6 +718,7 @@
 
 
     function handleData(d) {
+        d = { ...d, ...(d.tyres || d.tires || {}) };
         let tires = d.tyres || d.tires;
         if (!tires) {
             const comp = Array.isArray(d.carIdxTireCompounds) && typeof d.playerCarIdx==='number' ? (d.carIdxTireCompounds[d.playerCarIdx]||'U') : 'U';


### PR DESCRIPTION
## Summary
- display lap count in relative overlay
- clamp huge gap values
- expose tire data reliably
- show laps in the classification table and drop unused columns

## Testing
- `npm test --prefix telemetry-frontend`

------
https://chatgpt.com/codex/tasks/task_e_68464154c0048330a60634a2dbe1346c