### PR TITLE
Add overlay relative data

### DIFF
--- a/backend/Models/DriverInfo.cs
+++ b/backend/Models/DriverInfo.cs
@@ -16,6 +16,7 @@ namespace SuperBackendNR85IA.Models
         public int    CarClassID        { get; set; }
         public string CarClassShortName { get; set; } = string.Empty;
         public float  CarClassRelSpeed  { get; set; }
+        public float  CarClassEstLapTime { get; set; }
         public string TireCompound { get; set; } = string.Empty;
     }
 }

--- a/backend/Models/TelemetryModel.cs
+++ b/backend/Models/TelemetryModel.cs
@@ -131,6 +131,7 @@ namespace SuperBackendNR85IA.Models
         public string[] CarIdxLicStrings { get; set; } = Array.Empty<string>();
         public int[] CarIdxCarClassIds { get; set; } = Array.Empty<int>();
         public string[] CarIdxCarClassShortNames { get; set; } = Array.Empty<string>();
+        public float[] CarIdxCarClassEstLapTimes { get; set; } = Array.Empty<float>();
         public string[] CarIdxTireCompounds { get; set; } = Array.Empty<string>();
         public string CarAheadName { get; set; } = string.Empty;
         public string CarBehindName { get; set; } = string.Empty;

--- a/backend/Services/IRacingTelemetryService.Data.cs
+++ b/backend/Services/IRacingTelemetryService.Data.cs
@@ -434,6 +434,7 @@ namespace SuperBackendNR85IA.Services
             t.CarIdxLicStrings = orderedDrivers.Select(di => di.LicString).ToArray();
             t.CarIdxCarClassIds = orderedDrivers.Select(di => di.CarClassID).ToArray();
             t.CarIdxCarClassShortNames = orderedDrivers.Select(di => di.CarClassShortName).ToArray();
+            t.CarIdxCarClassEstLapTimes = orderedDrivers.Select(di => di.CarClassEstLapTime).ToArray();
             t.CarIdxTireCompounds = orderedDrivers.Select(di => di.TireCompound).ToArray();
 
 

--- a/backend/Services/SessionYamlParser.cs
+++ b/backend/Services/SessionYamlParser.cs
@@ -54,6 +54,7 @@ namespace SuperBackendNR85IA.Services
                 CarClassID        = GetInt(node, "CarClassID"),
                 CarClassShortName = GetStr(node, "CarClassShortName"),
                 CarClassRelSpeed  = GetFloat(node, "CarClassRelSpeed"),
+                CarClassEstLapTime = GetFloat(node, "CarClassEstLapTime"),
                 TireCompound      = GetTireCompound(node)
             };
         }
@@ -83,6 +84,7 @@ namespace SuperBackendNR85IA.Services
                     CarClassID        = GetInt(child, "CarClassID"),
                     CarClassShortName = GetStr(child, "CarClassShortName"),
                     CarClassRelSpeed  = GetFloat(child, "CarClassRelSpeed"),
+                    CarClassEstLapTime = GetFloat(child, "CarClassEstLapTime"),
                     TireCompound      = GetTireCompound(child)
                 });
             }

--- a/docs/overlay-relative-checklist.md
+++ b/docs/overlay-relative-checklist.md
@@ -1,0 +1,43 @@
+# Checklist de Dados Necessários para Overlay Relative
+
+Este documento resume os campos que o backend deve enviar para que a overlay **Relative** funcione corretamente.
+
+## Informações Gerais
+- **playerCarIdx** (int) – Índice do carro do jogador
+- **sessionNum** (int) – Número da sessão atual
+- **sessionTime** (float) – Tempo total da sessão
+- **sessionTimeRemain** (float) – Tempo restante da sessão
+- **lap** (int) – Volta atual do jogador
+- **totalLaps** (int) – Total de voltas da sessão (pode ser -1 se ilimitado)
+- **trackDisplayName** (string) – Nome da pista
+- **dcBrakeBias** (float) – Bias de freio do jogador
+
+## Dados Ambientais
+- **trackAirTemp** (float) – Temperatura do ar
+- **trackSurfaceTemp** (float) – Temperatura da pista
+
+## Arrays por CarIdx
+Os seguintes arrays devem ter o mesmo tamanho e conter a informação de todos os carros na sessão.
+- **carIdxPosition** (int[]) – Posição geral de cada carro
+- **carIdxLap** (int[]) – Volta atual de cada carro
+- **carIdxLapDistPct** (float[]) – Percentual percorrido na volta de cada carro
+- **carIdxOnPitRoad** (bool[]) – Indica se o carro está no pit
+- **carIdxTrackSurface** (int[]) – Estado da superfície do carro (0 a 7)
+- **carIdxLastLapTime** (float[]) – Último tempo de volta
+- **carIdxF2Time** (float[]) – Diferença de tempo F2 para o jogador
+- **carIdxCarClassEstLapTimes** (float[]) – Tempo estimado de volta de cada classe
+
+> **Importante:** verifique no frontend se o tamanho dos arrays é adequado antes de acessar os valores para evitar erros.
+
+## YAML da Sessão
+O campo **sessionInfoYaml** deve conter a string completa retornada por `GetSessionInfo()` do iRacing. Dela podem ser extraídos dados como:
+- `DriverInfo.Drivers[i]` com `CarIdx`, `UserName`, `CarNumberRaw`, `IRating`, `LicString`, `CarClassShortName` e `CarClassEstLapTime`.
+- `WeekendInfo.TrackDisplayName` e `WeekendInfo.TrackLength`.
+- `WeekendInfo.NumCarClasses` e `WeekendInfo.IncidentLimit`.
+- `SessionInfo.Sessions[i].SessionType` e outros detalhes de cada sessão.
+
+Sempre que o YAML mudar, o backend deve atualizar este campo para que a overlay possa reaproveitar as novas informações.
+
+## Dicas
+- Mantenha coerência entre `sessionTime`, temperaturas, voltas e o restante da sessão.
+- Campos derivados do YAML podem ser enviados já processados para simplificar a lógica no frontend.

--- a/ws/messages/overlay_message.json
+++ b/ws/messages/overlay_message.json
@@ -1,5 +1,23 @@
 {
-  "sessionInfoYaml": "",
+  "sessionInfoYaml": "...",
+  "playerCarIdx": 0,
+  "sessionNum": 1,
+  "sessionTime": 123.4,
+  "sessionTimeRemain": 600.0,
+  "lap": 5,
+  "totalLaps": 20,
+  "trackDisplayName": "Interlagos",
+  "dcBrakeBias": 0.55,
+  "trackAirTemp": 28.0,
+  "trackSurfaceTemp": 38.5,
+  "carIdxPosition": [1, 2],
+  "carIdxLap": [5, 5],
+  "carIdxLapDistPct": [0.5, 0.48],
+  "carIdxOnPitRoad": [false, false],
+  "carIdxTrackSurface": [1, 1],
+  "carIdxLastLapTime": [90.5, 91.0],
+  "carIdxF2Time": [0.0, 1.2],
+  "carIdxCarClassEstLapTimes": [89.5, 90.0],
   "yamlPlayerDriver": {
     "carIdx": 0,
     "userName": "Driver One"
@@ -9,13 +27,14 @@
     "trackConfigName": "Grand Prix"
   },
   "yamlSessionInfo": {
-    "sessionNum": 0,
+    "sessionNum": 1,
     "sessionType": "Practice"
   },
   "yamlSectorInfo": {
     "sectorCount": 3
   },
   "yamlDrivers": [
-    { "carIdx": 0, "userName": "Driver One" }
+    { "carIdx": 0, "userName": "Driver One" },
+    { "carIdx": 1, "userName": "Driver Two" }
   ]
 }


### PR DESCRIPTION
## Summary
- add CarClassEstLapTime to driver info
- expose carIdxCarClassEstLapTimes in telemetry model and populate from YAML
- update sample overlay message with relative fields
- document new array in relative checklist

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847330f3aa48330b73954d1f71b4b0a