### PR TITLE
Add best lap support

### DIFF
--- a/backend/Models/TelemetryModel.cs
+++ b/backend/Models/TelemetryModel.cs
@@ -119,6 +119,7 @@ namespace SuperBackendNR85IA.Models
         public bool[] CarIdxOnPitRoad { get; set; } = Array.Empty<bool>();
         public int[] CarIdxTrackSurface { get; set; } = Array.Empty<int>();
         public float[] CarIdxLastLapTime { get; set; } = Array.Empty<float>();
+        public float[] CarIdxBestLapTime { get; set; } = Array.Empty<float>();
         public float[] CarIdxF2Time { get; set; } = Array.Empty<float>();
         public float DistanceAhead { get; set; }
         public float DistanceBehind { get; set; }

--- a/backend/Services/IRacingTelemetryService.Data.cs
+++ b/backend/Services/IRacingTelemetryService.Data.cs
@@ -216,6 +216,7 @@ namespace SuperBackendNR85IA.Services
             var trackSurfaceArr = GetSdkArray<int>(d, "CarIdxTrackSurface")?.Select(v => v ?? 0).ToArray() ?? Array.Empty<int>();
             var lastLapArr      = GetSdkArray<float>(d, "CarIdxLastLapTime")?.Select(v => v ?? 0f).ToArray() ?? Array.Empty<float>();
             var f2TimeArr       = GetSdkArray<float>(d, "CarIdxF2Time")?.Select(v => v ?? 0f).ToArray() ?? Array.Empty<float>();
+            var bestLapArr      = GetSdkArray<float>(d, "CarIdxBestLapTime")?.Select(v => v ?? 0f).ToArray() ?? Array.Empty<float>();
             int myIdx           = GetSdkValue<int>(d, "PlayerCarIdx") ?? -1;
 
             if (myIdx >= 0 && myIdx < lapPctArr.Length && lapPctArr.Length == posArr.Length)
@@ -242,6 +243,7 @@ namespace SuperBackendNR85IA.Services
                 t.CarIdxOnPitRoad   = onPitArr;
                 t.CarIdxTrackSurface= trackSurfaceArr;
                 t.CarIdxLastLapTime = lastLapArr;
+                t.CarIdxBestLapTime = bestLapArr;
                 t.CarIdxF2Time      = f2TimeArr;
             }
             else
@@ -254,6 +256,7 @@ namespace SuperBackendNR85IA.Services
                 t.CarIdxOnPitRoad  = Array.Empty<bool>();
                 t.CarIdxTrackSurface= Array.Empty<int>();
                 t.CarIdxLastLapTime= Array.Empty<float>();
+                t.CarIdxBestLapTime= Array.Empty<float>();
                 t.CarIdxF2Time     = Array.Empty<float>();
             }
         }

--- a/telemetry-frontend/public/overlays/overlay-classificacao.html
+++ b/telemetry-frontend/public/overlays/overlay-classificacao.html
@@ -24,6 +24,7 @@
       <th>SR</th>
       <th>IR</th>
       <th>Piloto</th>
+      <th>Melhor</th>
       <th>Última</th>
       <th>Voltas</th>
       <th>Líder</th>
@@ -45,6 +46,7 @@ function update(data){
  const names=data.carIdxUserNames||[];
  const srs=data.carIdxLicStrings||[];
  const irs=data.carIdxIRatings||[];
+ const best=data.carIdxBestLapTime||[];
  const last=data.carIdxLastLapTime||[];
  const laps=data.carIdxLap||[];
  const f2=data.carIdxF2Time||[];
@@ -53,7 +55,7 @@ function update(data){
  const tbody=document.getElementById('tbody');
  tbody.innerHTML='';
  const cars=[];
- for(let i=0;i<pos.length;i++){if(pos[i]<=0)continue;cars.push({idx:i,pos:pos[i],num:nums[i]||'',name:names[i]||'',sr:srs[i]||'',ir:irs[i]||'',last:last[i]||0,lap:laps[i]||0,gap:f2[i]||0,pit:onPit[i],compound:compounds[i]||''});}
+ for(let i=0;i<pos.length;i++){if(pos[i]<=0)continue;cars.push({idx:i,pos:pos[i],num:nums[i]||'',name:names[i]||'',sr:srs[i]||'',ir:irs[i]||'',best:best[i]||0,last:last[i]||0,lap:laps[i]||0,gap:f2[i]||0,pit:onPit[i],compound:compounds[i]||''});}
  cars.sort((a,b)=>a.pos-b.pos);
  const leaderGap=cars.length>0?cars[0].gap:0;
  for(let i=0;i<cars.length;i++){
@@ -65,7 +67,7 @@ function update(data){
   let pitCell='';
   if(c.pit){pitStart[c.idx]=pitStart[c.idx]??data.sessionTime;pitCell=`<span class="pit-timer">${fmtTime(data.sessionTime-pitStart[c.idx])}</span>`;} else {delete pitStart[c.idx];}
   const tr=document.createElement('tr');
-  tr.innerHTML=`<td>${c.pos}</td><td>${c.num}</td><td>${c.sr}</td><td>${c.ir}</td><td>${c.name}</td><td>${fmtTime(c.last)}</td><td>${c.lap}</td><td>${gapL}</td><td>${gapA}</td><td>${pitCell}</td><td>${c.compound}</td>`;
+  tr.innerHTML=`<td>${c.pos}</td><td>${c.num}</td><td>${c.sr}</td><td>${c.ir}</td><td>${c.name}</td><td>${fmtTime(c.best)}</td><td>${fmtTime(c.last)}</td><td>${c.lap}</td><td>${gapL}</td><td>${gapA}</td><td>${pitCell}</td><td>${c.compound}</td>`;
   tbody.appendChild(tr);
  }
 }

--- a/ws/messages/overlay_message.json
+++ b/ws/messages/overlay_message.json
@@ -16,6 +16,7 @@
   "carIdxOnPitRoad": [false, false],
   "carIdxTrackSurface": [1, 1],
   "carIdxLastLapTime": [90.5, 91.0],
+  "carIdxBestLapTime": [89.8, 90.2],
   "carIdxF2Time": [0.0, 1.2],
   "carIdxCarClassEstLapTimes": [89.5, 90.0],
   "yamlPlayerDriver": {


### PR DESCRIPTION
## Summary
- expose `carIdxBestLapTime` in telemetry model and send in the WS payload
- read best lap array from the iRacing SDK
- show best lap time in the classificação overlay
- update example message

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684792c39504833092e5a2c16854d6bb