### PR TITLE
Fix TreadRemaining and capture hot pressures

### DIFF
--- a/backend/Models/TelemetryCalculationsOverlay.cs
+++ b/backend/Models/TelemetryCalculationsOverlay.cs
@@ -36,6 +36,11 @@ namespace SuperBackendNR85IA.Calculations
             model.Tyres.LrWear ??= new float[3];
             model.Tyres.RrWear ??= new float[3];
 
+            model.Tyres.LfTreadRemainingParts ??= model.Tyres.LfWear;
+            model.Tyres.RfTreadRemainingParts ??= model.Tyres.RfWear;
+            model.Tyres.LrTreadRemainingParts ??= model.Tyres.LrWear;
+            model.Tyres.RrTreadRemainingParts ??= model.Tyres.RrWear;
+
             model.Tyres.LfPress = model.Tyres.LfPress;
             model.Tyres.RfPress = model.Tyres.RfPress;
             model.Tyres.LrPress = model.Tyres.LrPress;

--- a/backend/Models/TelemetryModel.cs
+++ b/backend/Models/TelemetryModel.cs
@@ -70,6 +70,14 @@ namespace SuperBackendNR85IA.Models
         public float[] RfWear { get => Tyres.RfWear; set => Tyres.RfWear = value; }
         public float[] LrWear { get => Tyres.LrWear; set => Tyres.LrWear = value; }
         public float[] RrWear { get => Tyres.RrWear; set => Tyres.RrWear = value; }
+        public float[] LfTreadRemainingParts { get => Tyres.LfTreadRemainingParts; set => Tyres.LfTreadRemainingParts = value; }
+        public float[] RfTreadRemainingParts { get => Tyres.RfTreadRemainingParts; set => Tyres.RfTreadRemainingParts = value; }
+        public float[] LrTreadRemainingParts { get => Tyres.LrTreadRemainingParts; set => Tyres.LrTreadRemainingParts = value; }
+        public float[] RrTreadRemainingParts { get => Tyres.RrTreadRemainingParts; set => Tyres.RrTreadRemainingParts = value; }
+        public float LfLastHotPress { get => Tyres.LfLastHotPress; set => Tyres.LfLastHotPress = value; }
+        public float RfLastHotPress { get => Tyres.RfLastHotPress; set => Tyres.RfLastHotPress = value; }
+        public float LrLastHotPress { get => Tyres.LrLastHotPress; set => Tyres.LrLastHotPress = value; }
+        public float RrLastHotPress { get => Tyres.RrLastHotPress; set => Tyres.RrLastHotPress = value; }
         public float TreadRemainingFl { get => Tyres.TreadRemainingFl; set => Tyres.TreadRemainingFl = value; }
         public float TreadRemainingFr { get => Tyres.TreadRemainingFr; set => Tyres.TreadRemainingFr = value; }
         public float TreadRemainingRl { get => Tyres.TreadRemainingRl; set => Tyres.TreadRemainingRl = value; }
@@ -134,6 +142,7 @@ namespace SuperBackendNR85IA.Models
         public string[] CarIdxCarClassShortNames { get; set; } = Array.Empty<string>();
         public float[] CarIdxCarClassEstLapTimes { get; set; } = Array.Empty<float>();
         public string[] CarIdxTireCompounds { get; set; } = Array.Empty<string>();
+        public bool IsMultiClassSession { get; set; }
         public string CarAheadName { get; set; } = string.Empty;
         public string CarBehindName { get; set; } = string.Empty;
 

--- a/backend/Models/TyreData.cs
+++ b/backend/Models/TyreData.cs
@@ -27,6 +27,16 @@ namespace SuperBackendNR85IA.Models
         public float[] LrWear { get; set; } = Array.Empty<float>();
         public float[] RrWear { get; set; } = Array.Empty<float>();
 
+        public float[] LfTreadRemainingParts { get; set; } = Array.Empty<float>();
+        public float[] RfTreadRemainingParts { get; set; } = Array.Empty<float>();
+        public float[] LrTreadRemainingParts { get; set; } = Array.Empty<float>();
+        public float[] RrTreadRemainingParts { get; set; } = Array.Empty<float>();
+
+        public float LfLastHotPress { get; set; }
+        public float RfLastHotPress { get; set; }
+        public float LrLastHotPress { get; set; }
+        public float RrLastHotPress { get; set; }
+
         public float TreadRemainingFl { get; set; }
         public float TreadRemainingFr { get; set; }
         public float TreadRemainingRl { get; set; }

--- a/backend/Models/WeekendInfo.cs
+++ b/backend/Models/WeekendInfo.cs
@@ -13,8 +13,9 @@ namespace SuperBackendNR85IA.Models
         public float  RelativeHumidity { get; set; }
         public float  ChanceOfRain     { get; set; }
         public string ForecastType     { get; set; } = string.Empty;
-		public float TrackWindVel { get; set; }
-        public float TrackAirTemp { get; set; }
-        public string TrackNumTurns { get; set; }
+        public float  TrackWindVel      { get; set; }
+        public float  TrackAirTemp      { get; set; }
+        public string TrackNumTurns     { get; set; } = string.Empty;
+        public int    NumCarClasses     { get; set; }
     }
 }

--- a/backend/Services/IRacingTelemetryService.Data.cs
+++ b/backend/Services/IRacingTelemetryService.Data.cs
@@ -324,6 +324,11 @@ namespace SuperBackendNR85IA.Services
                 GetSdkValue<float>(d, "RRWearR")
             }.Select(v => v ?? 0f).ToArray();
 
+            t.Tyres.LfTreadRemainingParts = t.Tyres.LfWear;
+            t.Tyres.RfTreadRemainingParts = t.Tyres.RfWear;
+            t.Tyres.LrTreadRemainingParts = t.Tyres.LrWear;
+            t.Tyres.RrTreadRemainingParts = t.Tyres.RrWear;
+
             t.Tyres.TreadRemainingFl = GetSdkValue<float>(d, "LFWearM") ?? 0f;
             t.Tyres.TreadRemainingFr = GetSdkValue<float>(d, "RFWearM") ?? 0f;
             t.Tyres.TreadRemainingRl = GetSdkValue<float>(d, "LRWearM") ?? 0f;
@@ -439,6 +444,8 @@ namespace SuperBackendNR85IA.Services
             t.CarIdxCarClassShortNames = orderedDrivers.Select(di => di.CarClassShortName).ToArray();
             t.CarIdxCarClassEstLapTimes = orderedDrivers.Select(di => di.CarClassEstLapTime).ToArray();
             t.CarIdxTireCompounds = orderedDrivers.Select(di => di.TireCompound).ToArray();
+            t.IsMultiClassSession = (wkd?.NumCarClasses ?? 0) > 1 ||
+                                   t.CarIdxCarClassIds.Distinct().Count() > 1;
 
 
             if (wkd != null)

--- a/backend/Services/IRacingTelemetryService.cs
+++ b/backend/Services/IRacingTelemetryService.cs
@@ -34,6 +34,11 @@ namespace SuperBackendNR85IA.Services
         private string _carPath = string.Empty;
         private string _trackName = string.Empty;
         private bool _awaitingStoredData = false;
+        private bool _wasOnPitRoad = false;
+        private float _lfLastHotPress;
+        private float _rfLastHotPress;
+        private float _lrLastHotPress;
+        private float _rrLastHotPress;
 
         public IRacingTelemetryService(
             ILogger<IRacingTelemetryService> log,
@@ -117,11 +122,29 @@ namespace SuperBackendNR85IA.Services
             ComputeRelativeDistances(d, t);
             PopulateSessionInfo(d, t);
             PopulateTyres(d, t);
+            UpdateLastHotPress(t);
             await ApplyYamlData(d, t);
             RunCustomCalculations(d, t);
             await PersistCarTrackData(t);
 
             return t;
+        }
+
+        private void UpdateLastHotPress(TelemetryModel t)
+        {
+            if (t.OnPitRoad && !_wasOnPitRoad)
+            {
+                _lfLastHotPress = t.LfPress;
+                _rfLastHotPress = t.RfPress;
+                _lrLastHotPress = t.LrPress;
+                _rrLastHotPress = t.RrPress;
+            }
+            _wasOnPitRoad = t.OnPitRoad;
+
+            t.LfLastHotPress = _lfLastHotPress;
+            t.RfLastHotPress = _rfLastHotPress;
+            t.LrLastHotPress = _lrLastHotPress;
+            t.RrLastHotPress = _rrLastHotPress;
         }
     }
 }

--- a/backend/Services/SessionYamlParser.cs
+++ b/backend/Services/SessionYamlParser.cs
@@ -120,7 +120,8 @@ namespace SuperBackendNR85IA.Services
                 ForecastType     = GetStr(wNode, "ForecastType"),
                 TrackWindVel     = GetFloatFromSpecialFormat(wNode, "WindVel"),
                 TrackAirTemp     = GetFloatFromSpecialFormat(wNode, "AirTemp"),
-                TrackNumTurns    = GetStr(wNode, "TrackNumTurns")
+                TrackNumTurns    = GetStr(wNode, "TrackNumTurns"),
+                NumCarClasses    = GetInt(wNode, "NumCarClasses")
             };
         }
 

--- a/telemetry-frontend/public/overlays/overlay-relative.html
+++ b/telemetry-frontend/public/overlays/overlay-relative.html
@@ -470,7 +470,9 @@ function renderRelative(data) {
   // === Update Header and Footer ===
   document.getElementById('raceName').textContent = `Race: ${data.trackDisplayName || weekendInfo.TrackDisplayName || '--'}`;
   document.getElementById('raceTime').textContent = `Sim: ${fmtTimeSimple(data.sessionTime, false) || '00:00'}`;
-  document.getElementById('ambientTemp').textContent = `${typeof data.tempValue === 'number' ? data.tempValue.toFixed(1) : '--'}`; // Assuming tempValue for ambient
+  const amb = typeof data.trackAirTemp === 'number' ? data.trackAirTemp
+               : (typeof data.tempValue === 'number' ? data.tempValue : undefined);
+  document.getElementById('ambientTemp').textContent = `${typeof amb === 'number' ? amb.toFixed(1) : '--'}`;
   
   let trackTempValue = '--';
   if (typeof data.trackSurfaceTemp === 'number' && data.trackSurfaceTemp > -100) {

--- a/telemetry-frontend/public/overlays/overlaybase.html
+++ b/telemetry-frontend/public/overlays/overlaybase.html
@@ -150,7 +150,7 @@
         document.getElementById('raceTime').textContent = fmtTime(t);
       }
 
-      const ambient = data.weekendInfo?.trackAirTemp;
+      const ambient = data.trackAirTemp ?? data.weekendInfo?.trackAirTemp;
       if (ambient !== undefined) {
         document.getElementById('ambientTemp').textContent = Math.round(ambient);
       }


### PR DESCRIPTION
## Summary
- add per-wheel `TreadRemainingParts` arrays and expose them via websocket
- store `lfLastHotPress`…`rrLastHotPress` when entering pits
- keep last hot pressure values in telemetry output

## Testing
- `npm test --prefix telemetry-frontend`

------
https://chatgpt.com/codex/tasks/task_e_684814a3b1a08330b5698514ee4108b5