### PR TITLE
Fix overlay-tanque module import

### DIFF
--- a/telemetry-frontend/public/overlays/overlay-tanque.html
+++ b/telemetry-frontend/public/overlays/overlay-tanque.html
@@ -298,7 +298,8 @@
     </div>
   </div>
 
-  <script>
+  <script type="module">
+    import { initOverlayWebSocket, enableBrowserEditMode } from '../overlay-common.js';
     // --- Constantes e Variáveis de Estado ---
     const OVERLAY_NAME = 'overlay-tanque';
     const resizableOverlayWrapper = document.getElementById('wrapper');
@@ -718,9 +719,8 @@
     }
 
     // --- Inicialização ---
-    document.addEventListener('DOMContentLoaded', async () => {
+    document.addEventListener('DOMContentLoaded', () => {
       loadAllSettings(); // Carrega configurações primeiro
-      const { initOverlayWebSocket, enableBrowserEditMode } = await import('../overlay-common.js');
       isElectron = enableBrowserEditMode('wrapper','overlay-header');
       isCurrentlyInGlobalEditMode = !isElectron;
       initOverlayWebSocket(handleData);


### PR DESCRIPTION
## Summary
- convert overlay-tanque script to module
- use static import for common overlay helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847bc76e28c8330a8e4079b49b44264