### PR TITLE
Implement wind data parsing and IR delta

### DIFF
--- a/backend/Models/TelemetryCalculations.cs
+++ b/backend/Models/TelemetryCalculations.cs
@@ -142,6 +142,29 @@ namespace SuperBackendNR85IA.Calculations
             return (pct, status);
         }
 
+        // --- IRATING DELTA ---
+        public static int[] CalculateIRatingDeltas(int[] positions, int[] ratings, int playerIdx, int playerInc)
+        {
+            int n = Math.Min(positions.Length, ratings.Length);
+            int[] delta = new int[n];
+            const double K = 30.0;
+            for (int i = 0; i < n; i++)
+            {
+                double d = 0.0;
+                for (int j = 0; j < n; j++)
+                {
+                    if (i == j) continue;
+                    double expected = 1.0 / (1.0 + Math.Pow(10.0, (ratings[j] - ratings[i]) / 400.0));
+                    double actual = positions[i] < positions[j] ? 1.0 : 0.0;
+                    d += K * (actual - expected);
+                }
+                delta[i] = (int)Math.Round(d);
+            }
+            if (playerIdx >= 0 && playerIdx < n)
+                delta[playerIdx] -= playerInc;
+            return delta;
+        }
+
         // --- FUNÇÕES UTILIZADAS POR OVERLAYS ---
         public static void UpdateFuelData(ref TelemetryModel model)
         {

--- a/backend/Models/TelemetryModel.cs
+++ b/backend/Models/TelemetryModel.cs
@@ -230,11 +230,14 @@ namespace SuperBackendNR85IA.Models
         public string Skies { get; set; } = string.Empty;
         public string ForecastType { get; set; } = string.Empty;
         public float TrackWindVel { get; set; }
+        public float WindSpeed { get; set; }
+        public float WindDir { get; set; }
         public float AirPressure { get; set; }
         public float RelativeHumidity { get; set; }
         public float ChanceOfRain { get; set; }
         public int IncidentLimit { get; set; }
         public float TrackAirTemp { get; set; }
+        public int[] CarIdxIRatingDeltas { get; set; } = Array.Empty<int>();
         // Parsed YAML objects
         public WeekendInfo? YamlWeekendInfo { get; set; }
         public SessionInfo? YamlSessionInfo { get; set; }

--- a/backend/Models/WeekendInfo.cs
+++ b/backend/Models/WeekendInfo.cs
@@ -9,6 +9,7 @@ namespace SuperBackendNR85IA.Models
         public string SessionType      { get; set; } = string.Empty;
         public string Skies            { get; set; } = string.Empty;
         public float  WindSpeed        { get; set; }
+        public float  WindDir          { get; set; }
         public float  AirPressure      { get; set; }
         public float  RelativeHumidity { get; set; }
         public float  ChanceOfRain     { get; set; }

--- a/backend/Services/IRacingTelemetryService.Data.cs
+++ b/backend/Services/IRacingTelemetryService.Data.cs
@@ -444,6 +444,18 @@ namespace SuperBackendNR85IA.Services
             t.CarIdxCarClassShortNames = orderedDrivers.Select(di => di.CarClassShortName).ToArray();
             t.CarIdxCarClassEstLapTimes = orderedDrivers.Select(di => di.CarClassEstLapTime).ToArray();
             t.CarIdxTireCompounds = orderedDrivers.Select(di => di.TireCompound).ToArray();
+            if (t.CarIdxPosition.Length == t.CarIdxIRatings.Length && t.CarIdxPosition.Length > 0)
+            {
+                t.CarIdxIRatingDeltas = TelemetryCalculations.CalculateIRatingDeltas(
+                    t.CarIdxPosition,
+                    t.CarIdxIRatings,
+                    t.PlayerCarIdx,
+                    t.PlayerCarTeamIncidentCount);
+            }
+            else
+            {
+                t.CarIdxIRatingDeltas = Array.Empty<int>();
+            }
             t.IsMultiClassSession = (wkd?.NumCarClasses ?? 0) > 1 ||
                                    t.CarIdxCarClassIds.Distinct().Count() > 1;
 
@@ -457,6 +469,8 @@ namespace SuperBackendNR85IA.Services
                 t.Skies               = EnumTranslations.TranslateSkies(GetSdkValue<int>(d, "Skies") ?? 0);
                 t.ForecastType        = wkd.ForecastType;
                 t.TrackWindVel        = wkd.TrackWindVel;
+                t.WindSpeed           = wkd.WindSpeed;
+                t.WindDir             = wkd.WindDir;
                 t.TrackAirTemp        = wkd.TrackAirTemp;
                 t.TrackNumTurns       = wkd.TrackNumTurns;
                 t.AirPressure         = wkd.AirPressure;

--- a/backend/Services/SessionYamlParser.cs
+++ b/backend/Services/SessionYamlParser.cs
@@ -114,6 +114,7 @@ namespace SuperBackendNR85IA.Services
                 SessionType      = GetStr(wNode, "SessionType"),
                 Skies            = GetStr(wNode, "Skies"),
                 WindSpeed        = GetFloatFromSpecialFormat(wNode, "WindSpeed"), // Ex: "12 kph"
+                WindDir          = GetFloatFromSpecialFormat(wNode, "WindDir"),
                 AirPressure      = GetFloatFromSpecialFormat(wNode, "AirPressure"), // Ex: "29.00 Hg" ou "101.2 kPa"
                 RelativeHumidity = GetFloatFromSpecialFormat(wNode, "RelativeHumidity"), // Ex: "50.0 %"
                 ChanceOfRain     = GetFloatFromSpecialFormat(wNode, "ChanceOfRain"),     // Ex: "0.0 %"

--- a/telemetry-frontend/public/overlays/overlay-classificacao.html
+++ b/telemetry-frontend/public/overlays/overlay-classificacao.html
@@ -23,6 +23,7 @@
       <th>#</th>
       <th>SR</th>
       <th>IR</th>
+      <th>ΔIR</th>
       <th>Piloto</th>
       <th>Melhor</th>
       <th>Última</th>
@@ -45,6 +46,7 @@ function update(data){
  const names=data.carIdxUserNames||[];
  const srs=data.carIdxLicStrings||[];
  const irs=data.carIdxIRatings||[];
+ const irDelta=data.carIdxIRatingDeltas||[];
  const best=data.carIdxBestLapTime||[];
  const last=data.carIdxLastLapTime||[];
  const laps=data.carIdxLap||[];
@@ -54,7 +56,7 @@ function update(data){
  const tbody=document.getElementById('tbody');
  tbody.innerHTML='';
  const cars=[];
- for(let i=0;i<pos.length;i++){if(pos[i]<=0)continue;cars.push({idx:i,pos:pos[i],num:nums[i]||'',name:names[i]||'',sr:srs[i]||'',ir:irs[i]||'',best:best[i]||0,last:last[i]||0,lap:laps[i]||0,gap:f2[i]||0,pit:onPit[i],compound:compounds[i]||''});}
+ for(let i=0;i<pos.length;i++){if(pos[i]<=0)continue;cars.push({idx:i,pos:pos[i],num:nums[i]||'',name:names[i]||'',sr:srs[i]||'',ir:irs[i]||'',delta:irDelta[i]||0,best:best[i]||0,last:last[i]||0,lap:laps[i]||0,gap:f2[i]||0,pit:onPit[i],compound:compounds[i]||''});}
  cars.sort((a,b)=>a.pos-b.pos);
  const leaderGap=cars.length>0?cars[0].gap:0;
  for(let i=0;i<cars.length;i++){
@@ -66,7 +68,7 @@ function update(data){
   let pitCell='';
   if(c.pit){pitStart[c.idx]=pitStart[c.idx]??data.sessionTime;pitCell=`<span class="pit-timer">${fmtTime(data.sessionTime-pitStart[c.idx])}</span>`;} else {delete pitStart[c.idx];}
   const tr=document.createElement('tr');
-  tr.innerHTML=`<td>${c.pos}</td><td>${c.num}</td><td>${c.sr}</td><td>${c.ir}</td><td>${c.name}</td><td>${fmtTime(c.best)}</td><td>${fmtTime(c.last)}</td><td>${c.lap}</td><td>${gapL}</td><td>${gapA}</td><td>${pitCell}</td><td>${c.compound}</td>`;
+  tr.innerHTML=`<td>${c.pos}</td><td>${c.num}</td><td>${c.sr}</td><td>${c.ir}</td><td>${c.delta>0?"+":""}${c.delta}</td><td>${c.name}</td><td>${fmtTime(c.best)}</td><td>${fmtTime(c.last)}</td><td>${c.lap}</td><td>${gapL}</td><td>${gapA}</td><td>${pitCell}</td><td>${c.compound}</td>`;
   tbody.appendChild(tr);
  }
 }


### PR DESCRIPTION
## Summary
- parse wind speed/direction from session YAML
- expose wind data and iRating delta in backend payloads
- compute rating deltas using simple ELO-like formula
- show ΔIR column in classification overlay

## Testing
- `npm test`
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684853a4db248330a9fd3c4cd0201d65