### PR TITLE
Fix overlay field names

### DIFF
--- a/telemetry-frontend/public/overlays/overlay-relative.html
+++ b/telemetry-frontend/public/overlays/overlay-relative.html
@@ -453,22 +453,42 @@ function renderRelative(data) {
   // Flatten possible sub-models from new TelemetryModel structure
   data = { ...data, ...(data.session || {}), ...(data.vehicle || {}), ...(data.tyres || {}), ...(data.damage || {}) };
 
-  // Parse YAML only if it has changed
-  if (data.sessionInfoYaml && data.sessionInfoYaml !== lastSessionInfoYaml) {
+  // Prefer typed YAML objects from the backend when available
+  if (Array.isArray(data.yamlDrivers)) {
+      cachedDriverInfo = data.yamlDrivers;
+  }
+  if (data.yamlWeekendInfo) {
+      cachedWeekendInfo = data.yamlWeekendInfo;
+  }
+  if (data.yamlSessionInfo) {
+      cachedSessionInfo = data.yamlSessionInfo;
+  }
+
+  // Fallback: parse raw YAML only if we still don't have info
+  if (!cachedDriverInfo && data.sessionInfoYaml && data.sessionInfoYaml !== lastSessionInfoYaml) {
       const parsedYaml = parseYaml(data.sessionInfoYaml);
       cachedDriverInfo = parsedYaml?.DriverInfo?.Drivers;
       cachedWeekendInfo = parsedYaml?.WeekendInfo;
-      cachedSessionInfo = parsedYaml?.SessionInfo?.Sessions;
+      cachedSessionInfo = parsedYaml?.SessionInfo;
       lastSessionInfoYaml = data.sessionInfoYaml;
   }
 
   const weekendInfo = cachedWeekendInfo || {};
-  const currentSessionYamlData = (cachedSessionInfo || []).find(s => s.SessionNum === data.sessionNum) || {};
-  const playerDriverYaml = (cachedDriverInfo || []).find(d => d.CarIdx === data.playerCarIdx);
+  let currentSessionYamlData = {};
+  if (cachedSessionInfo) {
+      if (Array.isArray(cachedSessionInfo.allSessionsFromYaml)) {
+          currentSessionYamlData = cachedSessionInfo.allSessionsFromYaml.find(s => s.sessionNum === data.sessionNum) || cachedSessionInfo;
+      } else if (Array.isArray(cachedSessionInfo)) {
+          currentSessionYamlData = cachedSessionInfo.find(s => s.SessionNum === data.sessionNum) || {};
+      } else {
+          currentSessionYamlData = cachedSessionInfo;
+      }
+  }
+  const playerDriverYaml = (cachedDriverInfo || []).find(d => (d.carIdx ?? d.CarIdx) === data.playerCarIdx);
 
 
   // === Update Header and Footer ===
-  document.getElementById('raceName').textContent = `Race: ${data.trackDisplayName || weekendInfo.TrackDisplayName || '--'}`;
+  document.getElementById('raceName').textContent = `Race: ${data.trackDisplayName || weekendInfo.trackDisplayName || '--'}`;
   document.getElementById('raceTime').textContent = `Sim: ${fmtTimeSimple(data.sessionTime, false) || '00:00'}`;
   const amb = typeof data.trackAirTemp === 'number' ? data.trackAirTemp
                : (typeof data.tempValue === 'number' ? data.tempValue : undefined);
@@ -485,12 +505,14 @@ function renderRelative(data) {
   
   document.getElementById('sessionTimeRemaining').textContent = `${fmtTimeSimple(data.sessionTimeRemain, false) || '00:00'}`;
   const playerLap = data.lap ?? '--';
-  const totalLapsSess = currentSessionYamlData?.SessionLapsTotal === -1 ? '∞' : (currentSessionYamlData?.SessionLapsTotal ?? '--'); // Adjust to use SessionLapsTotal from YAML if available and needed
+  const totalLapsSess = currentSessionYamlData?.currentSessionTotalLaps === -1
+        ? '∞'
+        : (currentSessionYamlData?.currentSessionTotalLaps ?? currentSessionYamlData?.sessionLapsTotal ?? '--');
   document.getElementById('lapsCompleted').textContent = `${playerLap}`;
   document.getElementById('totalLaps').textContent = `${totalLapsSess}`;
 
   // Use IncidentLimit from the current session in YAML
-  const incidentLimit = currentSessionYamlData?.IncidentLimit || weekendInfo.IncidentLimit || 'N/A';
+  const incidentLimit = currentSessionYamlData?.incidentLimit ?? weekendInfo.incidentLimit ?? 'N/A';
   const playerIncidents = data.playerCarTeamIncidentCount ?? '--';
   const penaltyEl = document.getElementById('penaltyStatus');
   penaltyEl.textContent = `Inc: ${playerIncidents}/${incidentLimit}`;
@@ -551,7 +573,7 @@ function renderRelative(data) {
   // and try to match with real-time data from backend
   for (let i = 0; i < driversFromYaml.length; i++) {
     const driverYaml = driversFromYaml[i];
-    const carIdx = driverYaml.CarIdx;
+    const carIdx = driverYaml.carIdx ?? driverYaml.CarIdx;
 
     // We need real-time position for filtering/sorting. If not available, skip.
     // Assuming carPositionsFromBackend has valid position at carIdx.
@@ -561,13 +583,13 @@ function renderRelative(data) {
     carsData.push({
       idx: carIdx,
       pos: pos,
-      num: driverYaml.CarNumberRaw !== undefined ? driverYaml.CarNumberRaw.toString() : (driverYaml.CarNumber || '--'),
-      name: driverYaml.UserName || 'Desconhecido',
-      team: driverYaml.TeamName || '',
-      irating: driverYaml.IRating || 0,
-      lic: driverYaml.LicString || 'R ----',
-      carClassShort: driverYaml.CarClassShortName || '',
-      carScreenName: driverYaml.CarScreenName || '',
+      num: driverYaml.carNumberRaw !== undefined ? driverYaml.carNumberRaw.toString() : (driverYaml.carNumber ?? driverYaml.CarNumber || '--'),
+      name: driverYaml.userName ?? driverYaml.UserName || 'Desconhecido',
+      team: driverYaml.teamName ?? driverYaml.TeamName || '',
+      irating: driverYaml.iRating ?? driverYaml.IRating || 0,
+      lic: driverYaml.licString ?? driverYaml.LicString || 'R ----',
+      carClassShort: driverYaml.carClassShortName ?? driverYaml.CarClassShortName || '',
+      carScreenName: driverYaml.carScreenName ?? driverYaml.CarScreenName || '',
       lap: carLapsCompletedFromBackend[carIdx],
       lastLapTime: carLastLapTimesFromBackend[carIdx],
       onPit: carOnPitRoadFromBackend[carIdx],

--- a/telemetry-frontend/public/overlays/overlay-testefinal.html
+++ b/telemetry-frontend/public/overlays/overlay-testefinal.html
@@ -549,10 +549,10 @@ function render(data) {
   addRow('Sets Disponíveis', data.tireSetsAvailable); 
 
   tires.forEach((tire) => { // tire já é o prefixo em minúsculas
-    addRow(`${tire.toUpperCase()} Temp CL`, data[`${tire}tempCL`], fmtGenericValue, '°C');
-    addRow(`${tire.toUpperCase()} Temp CM`, data[`${tire}tempCM`], fmtGenericValue, '°C');
-    addRow(`${tire.toUpperCase()} Temp CR`, data[`${tire}tempCR`], fmtGenericValue, '°C');
-    addRow(`${tire.toUpperCase()} Pressão`, data[`${tire}press`], fmtGenericValue, 'kPa');
+    addRow(`${tire.toUpperCase()} Temp CL`, data[`${tire}TempCl`], fmtGenericValue, '°C');
+    addRow(`${tire.toUpperCase()} Temp CM`, data[`${tire}TempCm`], fmtGenericValue, '°C');
+    addRow(`${tire.toUpperCase()} Temp CR`, data[`${tire}TempCr`], fmtGenericValue, '°C');
+    addRow(`${tire.toUpperCase()} Pressão`, data[`${tire}Press`], fmtGenericValue, 'kPa');
     const wearArray = data[`${tire}Wear`]; 
     let wearText = "— / — / —";
     if(Array.isArray(wearArray) && wearArray.length >= 3){
@@ -564,7 +564,7 @@ function render(data) {
   addSection('🛑 Freios, Pit & Ajustes (DC)');
   const tireCornersUpper = ['LF', 'RF', 'LR', 'RR'];
   tireCornersUpper.forEach((corner, index) => addRow(`Temp. Freio ${corner}`, data.brakeTemp ? data.brakeTemp[index] : undefined, fmtGenericValue, '°C'));
-  tireCornersUpper.forEach(corner => addRow(`Pressão Linha Freio ${corner}`, data[`${corner.toLowerCase()}brakeLinePress`], fmtGenericValue, 'kPa'));
+  tireCornersUpper.forEach(corner => addRow(`Pressão Linha Freio ${corner}`, data[`${corner.toLowerCase()}BrakeLinePress`], fmtGenericValue, 'kPa'));
   addRow('Balanço Freio', data.dcBrakeBias, v => (v * 100).toFixed(1), '%');
   addRow('Nos Pits', data.onPitRoad, fmtGenericValue);
   addRow('Reparo Restante (Obrig.)', data.pitRepairLeft, fmtTime);
@@ -655,21 +655,21 @@ function render(data) {
     trackGripStatus: 'Aderência Pista', drs_Status: 'Status DRS', // Assumindo drs_Status
     dcEnginePower: 'Modo Motor ERS (DC)', pitRepairLeft: 'Reparo Obrig. Restante',
     pitOptRepairLeft: 'Reparo Opc. Restante',
-    lftempCL: 'LF Temp CL', lftempCM: 'LF Temp CM', lftempCR: 'LF Temp CR',
-    rftempCL: 'RF Temp CL', rftempCM: 'RF Temp CM', rftempCR: 'RF Temp CR',
-    lrtempCL: 'LR Temp CL', lrtempCM: 'LR Temp CM', lrtempCR: 'LR Temp CR',
-    rrtempCL: 'RR Temp CL', rrtempCM: 'RR Temp CM', rrtempCR: 'RR Temp CR',
-    lfpress: 'LF Pressão', rfpress: 'RF Pressão', lrpress: 'LR Pressão', rrpress: 'RR Pressão',
+    lfTempCl: 'LF Temp CL', lfTempCm: 'LF Temp CM', lfTempCr: 'LF Temp CR',
+    rfTempCl: 'RF Temp CL', rfTempCm: 'RF Temp CM', rfTempCr: 'RF Temp CR',
+    lrTempCl: 'LR Temp CL', lrTempCm: 'LR Temp CM', lrTempCr: 'LR Temp CR',
+    rrTempCl: 'RR Temp CL', rrTempCm: 'RR Temp CM', rrTempCr: 'RR Temp CR',
+    lfPress: 'LF Pressão', rfPress: 'RF Pressão', lrPress: 'LR Pressão', rrPress: 'RR Pressão',
     lfWear: 'LF Desgaste', rfWear: 'RF Desgaste', lrWear: 'LR Desgaste', rrWear: 'RR Desgaste',
     playerCarTireCompound: 'Composto Pneu Jogador',
     tireSetsUsed: 'Sets Pneus Usados', tireSetsAvailable: 'Sets Pneus Disponíveis',
     brakeTemp: 'Temp. Freio (Array)',
-    lfbrakeLinePress: 'LF Pressão Linha Freio', rfbrakeLinePress: 'RF Pressão Linha Freio',
-    lrbrakeLinePress: 'LR Pressão Linha Freio', rrbrakeLinePress: 'RR Pressão Linha Freio',
-    lfsuspPos: 'LF Pos. Susp.', rfsuspPos: 'RF Pos. Susp.', lrsuspPos: 'LR Pos. Susp.', rrsuspPos: 'RR Pos. Susp.',
-    lfsuspVel: 'LF Vel. Susp.', rfsuspVel: 'RF Vel. Susp.', lrsuspVel: 'LR Vel. Susp.', rrsuspVel: 'RR Vel. Susp.',
-    lfrideHeight: 'LF Alt. Monoposto', rfrideHeight: 'RF Alt. Monoposto', 
-    lrrideHeight: 'LR Alt. Monoposto', rrrideHeight: 'RR Alt. Monoposto',
+    lfBrakeLinePress: 'LF Pressão Linha Freio', rfBrakeLinePress: 'RF Pressão Linha Freio',
+    lrBrakeLinePress: 'LR Pressão Linha Freio', rrBrakeLinePress: 'RR Pressão Linha Freio',
+    lfSuspPos: 'LF Pos. Susp.', rfSuspPos: 'RF Pos. Susp.', lrSuspPos: 'LR Pos. Susp.', rrSuspPos: 'RR Pos. Susp.',
+    lfSuspVel: 'LF Vel. Susp.', rfSuspVel: 'RF Vel. Susp.', lrSuspVel: 'LR Vel. Susp.', rrSuspVel: 'RR Vel. Susp.',
+    lfRideHeight: 'LF Alt. Monoposto', rfRideHeight: 'RF Alt. Monoposto',
+    lrRideHeight: 'LR Alt. Monoposto', rrRideHeight: 'RR Alt. Monoposto',
     lfDamage: 'LF Dano', rfDamage: 'RF Dano', lrDamage: 'LR Dano', rrDamage: 'RR Dano',
     frontWingDamage: 'Dano Asa Diant.', rearWingDamage: 'Dano Asa Tras.',
     engineDamage: 'Dano Motor', gearboxDamage: 'Dano Câmbio',


### PR DESCRIPTION
## Summary
- align property names in the `overlay-testefinal.html` overlay with backend camelCase fields
- use typed YAML data in `overlay-relative.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849049f74a08330910944453e92b2ea