### PR TITLE
Add more telemetry fields in backend

### DIFF
--- a/backend/Models/SessionData.cs
+++ b/backend/Models/SessionData.cs
@@ -12,5 +12,16 @@ namespace SuperBackendNR85IA.Models
         public int TotalLaps { get; set; }
         public int LapsRemainingRace { get; set; }
         public string SessionTypeFromYaml { get; set; } = string.Empty;
+
+        // Additional session telemetry
+        public float SessionTimeTotal { get; set; }
+        public int SessionLapsTotal { get; set; }
+        public int SessionLapsRemain { get; set; }
+        public int RaceLaps { get; set; }
+        public bool PitsOpen { get; set; }
+
+        public long SessionUniqueID { get; set; }
+        public int SessionTick { get; set; }
+        public bool SessionOnJokerLap { get; set; }
     }
 }

--- a/backend/Models/TelemetryModel.cs
+++ b/backend/Models/TelemetryModel.cs
@@ -21,6 +21,14 @@ namespace SuperBackendNR85IA.Models
         public int PlayerCarIdx { get => Session.PlayerCarIdx; set => Session.PlayerCarIdx = value; }
         public int TotalLaps { get => Session.TotalLaps; set => Session.TotalLaps = value; }
         public int LapsRemainingRace { get => Session.LapsRemainingRace; set => Session.LapsRemainingRace = value; }
+        public float SessionTimeTotal { get => Session.SessionTimeTotal; set => Session.SessionTimeTotal = value; }
+        public int SessionLapsTotal { get => Session.SessionLapsTotal; set => Session.SessionLapsTotal = value; }
+        public int SessionLapsRemain { get => Session.SessionLapsRemain; set => Session.SessionLapsRemain = value; }
+        public int RaceLaps { get => Session.RaceLaps; set => Session.RaceLaps = value; }
+        public bool PitsOpen { get => Session.PitsOpen; set => Session.PitsOpen = value; }
+        public long SessionUniqueID { get => Session.SessionUniqueID; set => Session.SessionUniqueID = value; }
+        public int SessionTick { get => Session.SessionTick; set => Session.SessionTick = value; }
+        public bool SessionOnJokerLap { get => Session.SessionOnJokerLap; set => Session.SessionOnJokerLap = value; }
         public string SessionTypeFromYaml { get => Session.SessionTypeFromYaml; set => Session.SessionTypeFromYaml = value; }
 
         public string SessionTimeFormatted => FormatTime(Session.SessionTime);
@@ -48,6 +56,29 @@ namespace SuperBackendNR85IA.Models
         public float PitRepairLeft { get => Vehicle.PitRepairLeft; set => Vehicle.PitRepairLeft = value; }
         public float PitOptRepairLeft { get => Vehicle.PitOptRepairLeft; set => Vehicle.PitOptRepairLeft = value; }
         public float CarSpeed { get => Vehicle.CarSpeed; set => Vehicle.CarSpeed = value; }
+        public float ThrottleRaw { get => Vehicle.ThrottleRaw; set => Vehicle.ThrottleRaw = value; }
+        public float BrakeRaw { get => Vehicle.BrakeRaw; set => Vehicle.BrakeRaw = value; }
+        public bool BrakeABSactive { get => Vehicle.BrakeABSactive; set => Vehicle.BrakeABSactive = value; }
+        public float BrakeABSCutPct { get => Vehicle.BrakeABSCutPct; set => Vehicle.BrakeABSCutPct = value; }
+        public float HandBrake { get => Vehicle.HandBrake; set => Vehicle.HandBrake = value; }
+        public float HandBrakeRaw { get => Vehicle.HandBrakeRaw; set => Vehicle.HandBrakeRaw = value; }
+        public float SteeringWheelAngleMax { get => Vehicle.SteeringWheelAngleMax; set => Vehicle.SteeringWheelAngleMax = value; }
+        public int SteeringWheelLimiter { get => Vehicle.SteeringWheelLimiter; set => Vehicle.SteeringWheelLimiter = value; }
+        public float SteeringWheelTorque { get => Vehicle.SteeringWheelTorque; set => Vehicle.SteeringWheelTorque = value; }
+        public float SteeringWheelPeakForceNm { get => Vehicle.SteeringWheelPeakForceNm; set => Vehicle.SteeringWheelPeakForceNm = value; }
+        public float YawRate { get => Vehicle.YawRate; set => Vehicle.YawRate = value; }
+        public float PitchRate { get => Vehicle.PitchRate; set => Vehicle.PitchRate = value; }
+        public float RollRate { get => Vehicle.RollRate; set => Vehicle.RollRate = value; }
+        public float SteeringWheelPctDamper { get => Vehicle.SteeringWheelPctDamper; set => Vehicle.SteeringWheelPctDamper = value; }
+        public float SteeringWheelPctTorque { get => Vehicle.SteeringWheelPctTorque; set => Vehicle.SteeringWheelPctTorque = value; }
+        public float SteeringWheelPctTorqueSign { get => Vehicle.SteeringWheelPctTorqueSign; set => Vehicle.SteeringWheelPctTorqueSign = value; }
+        public float SteeringWheelPctTorqueSignStops { get => Vehicle.SteeringWheelPctTorqueSignStops; set => Vehicle.SteeringWheelPctTorqueSignStops = value; }
+        public float EnergyERSBattery { get => Vehicle.EnergyERSBattery; set => Vehicle.EnergyERSBattery = value; }
+        public float EnergyERSBatteryPct { get => Vehicle.EnergyERSBatteryPct; set => Vehicle.EnergyERSBatteryPct = value; }
+        public float EnergyMGU_KLapDeployPct { get => Vehicle.EnergyMGU_KLapDeployPct; set => Vehicle.EnergyMGU_KLapDeployPct = value; }
+        public float EnergyBatteryToMGU_KLap { get => Vehicle.EnergyBatteryToMGU_KLap; set => Vehicle.EnergyBatteryToMGU_KLap = value; }
+        public bool ManualBoost { get => Vehicle.ManualBoost; set => Vehicle.ManualBoost = value; }
+        public bool ManualNoBoost { get => Vehicle.ManualNoBoost; set => Vehicle.ManualNoBoost = value; }
 
         // ---- Tyres ----
         public float LfTempCl { get => Tyres.LfTempCl; set => Tyres.LfTempCl = value; }
@@ -144,6 +175,12 @@ namespace SuperBackendNR85IA.Models
         public string[] CarIdxCarClassShortNames { get; set; } = Array.Empty<string>();
         public float[] CarIdxCarClassEstLapTimes { get; set; } = Array.Empty<float>();
         public string[] CarIdxTireCompounds { get; set; } = Array.Empty<string>();
+        public int[] CarIdxGear { get; set; } = Array.Empty<int>();
+        public float[] CarIdxRPM { get; set; } = Array.Empty<float>();
+        public int[] CarIdxPaceFlags { get; set; } = Array.Empty<int>();
+        public int[] CarIdxPaceLine { get; set; } = Array.Empty<int>();
+        public int[] CarIdxPaceRow { get; set; } = Array.Empty<int>();
+        public int[] CarIdxTrackSurfaceMaterial { get; set; } = Array.Empty<int>();
         public bool IsMultiClassSession { get; set; }
         public string CarAheadName { get; set; } = string.Empty;
         public string CarBehindName { get; set; } = string.Empty;
@@ -236,8 +273,19 @@ namespace SuperBackendNR85IA.Models
         public float TrackWindVel { get; set; }
         public float WindSpeed { get; set; }
         public float WindDir { get; set; }
+        public float AirTemp { get; set; }
+        public float TrackAltitude { get; set; }
+        public float TrackLatitude { get; set; }
+        public float TrackLongitude { get; set; }
         public float AirPressure { get; set; }
         public float RelativeHumidity { get; set; }
+        public float AirDensity { get; set; }
+        public float FogLevel { get; set; }
+        public float Precipitation { get; set; }
+        public bool WeatherDeclaredWet { get; set; }
+        public float SolarAltitude { get; set; }
+        public float SolarAzimuth { get; set; }
+        public string CarLeftRight { get; set; } = string.Empty;
         public float ChanceOfRain { get; set; }
         public int IncidentLimit { get; set; }
         public float TrackAirTemp { get; set; }

--- a/backend/Models/VehicleData.cs
+++ b/backend/Models/VehicleData.cs
@@ -23,5 +23,32 @@ namespace SuperBackendNR85IA.Models
         public float PitRepairLeft { get; set; }
         public float PitOptRepairLeft { get; set; }
         public float CarSpeed { get; set; }
+
+        // Extra controls and dynamics
+        public float ThrottleRaw { get; set; }
+        public float BrakeRaw { get; set; }
+        public bool BrakeABSactive { get; set; }
+        public float BrakeABSCutPct { get; set; }
+        public float HandBrake { get; set; }
+        public float HandBrakeRaw { get; set; }
+        public float SteeringWheelAngleMax { get; set; }
+        public int SteeringWheelLimiter { get; set; }
+        public float SteeringWheelTorque { get; set; }
+        public float SteeringWheelPeakForceNm { get; set; }
+        public float YawRate { get; set; }
+        public float PitchRate { get; set; }
+        public float RollRate { get; set; }
+
+        // Additional dynamics and energy systems
+        public float SteeringWheelPctDamper { get; set; }
+        public float SteeringWheelPctTorque { get; set; }
+        public float SteeringWheelPctTorqueSign { get; set; }
+        public float SteeringWheelPctTorqueSignStops { get; set; }
+        public float EnergyERSBattery { get; set; }
+        public float EnergyERSBatteryPct { get; set; }
+        public float EnergyMGU_KLapDeployPct { get; set; }
+        public float EnergyBatteryToMGU_KLap { get; set; }
+        public bool ManualBoost { get; set; }
+        public bool ManualNoBoost { get; set; }
     }
 }

--- a/backend/Services/IRacingTelemetryService.Data.cs
+++ b/backend/Services/IRacingTelemetryService.Data.cs
@@ -125,6 +125,29 @@ namespace SuperBackendNR85IA.Services
             t.Vehicle.PitRepairLeft      = GetSdkValue<float>(d, "PitRepairLeft") ?? 0f;
             t.Vehicle.PitOptRepairLeft   = GetSdkValue<float>(d, "PitOptRepairLeft") ?? 0f;
             t.Vehicle.CarSpeed = t.Vehicle.Speed;
+            t.Vehicle.ThrottleRaw        = GetSdkValue<float>(d, "ThrottleRaw") ?? 0f;
+            t.Vehicle.BrakeRaw           = GetSdkValue<float>(d, "BrakeRaw") ?? 0f;
+            t.Vehicle.BrakeABSactive     = GetSdkValue<bool>(d, "BrakeABSactive") ?? false;
+            t.Vehicle.BrakeABSCutPct     = GetSdkValue<float>(d, "BrakeABSCutPct") ?? 0f;
+            t.Vehicle.HandBrake          = GetSdkValue<float>(d, "HandBrake") ?? 0f;
+            t.Vehicle.HandBrakeRaw       = GetSdkValue<float>(d, "HandBrakeRaw") ?? 0f;
+            t.Vehicle.SteeringWheelAngleMax = GetSdkValue<float>(d, "SteeringWheelAngleMax") ?? 0f;
+            t.Vehicle.SteeringWheelLimiter  = GetSdkValue<int>(d, "SteeringWheelLimiter") ?? 0;
+            t.Vehicle.SteeringWheelTorque   = GetSdkValue<float>(d, "SteeringWheelTorque") ?? 0f;
+            t.Vehicle.SteeringWheelPeakForceNm = GetSdkValue<float>(d, "SteeringWheelPeakForceNm") ?? 0f;
+            t.Vehicle.YawRate            = GetSdkValue<float>(d, "YawRate") ?? 0f;
+            t.Vehicle.PitchRate          = GetSdkValue<float>(d, "PitchRate") ?? 0f;
+            t.Vehicle.RollRate           = GetSdkValue<float>(d, "RollRate") ?? 0f;
+            t.Vehicle.SteeringWheelPctDamper = GetSdkValue<float>(d, "SteeringWheelPctDamper") ?? 0f;
+            t.Vehicle.SteeringWheelPctTorque = GetSdkValue<float>(d, "SteeringWheelPctTorque") ?? 0f;
+            t.Vehicle.SteeringWheelPctTorqueSign = GetSdkValue<float>(d, "SteeringWheelPctTorqueSign") ?? 0f;
+            t.Vehicle.SteeringWheelPctTorqueSignStops = GetSdkValue<float>(d, "SteeringWheelPctTorqueSignStops") ?? 0f;
+            t.Vehicle.EnergyERSBattery        = GetSdkValue<float>(d, "EnergyERSBattery") ?? 0f;
+            t.Vehicle.EnergyERSBatteryPct     = GetSdkValue<float>(d, "EnergyERSBatteryPct") ?? 0f;
+            t.Vehicle.EnergyMGU_KLapDeployPct = GetSdkValue<float>(d, "EnergyMGU_KLapDeployPct") ?? 0f;
+            t.Vehicle.EnergyBatteryToMGU_KLap = GetSdkValue<float>(d, "EnergyBatteryToMGU_KLap") ?? 0f;
+            t.Vehicle.ManualBoost             = GetSdkValue<bool>(d, "ManualBoost") ?? false;
+            t.Vehicle.ManualNoBoost           = GetSdkValue<bool>(d, "ManualNoBoost") ?? false;
         }
 
         private void UpdateLapInfo(IRacingSdkData d, TelemetryModel t)
@@ -220,6 +243,12 @@ namespace SuperBackendNR85IA.Services
             var lastLapArr      = GetSdkArray<float>(d, "CarIdxLastLapTime")?.Select(v => v ?? 0f).ToArray() ?? Array.Empty<float>();
             var f2TimeArr       = GetSdkArray<float>(d, "CarIdxF2Time")?.Select(v => v ?? 0f).ToArray() ?? Array.Empty<float>();
             var bestLapArr      = GetSdkArray<float>(d, "CarIdxBestLapTime")?.Select(v => v ?? 0f).ToArray() ?? Array.Empty<float>();
+            var gearArr         = GetSdkArray<int>(d, "CarIdxGear")?.Select(v => v ?? 0).ToArray() ?? Array.Empty<int>();
+            var rpmArr          = GetSdkArray<float>(d, "CarIdxRPM")?.Select(v => v ?? 0f).ToArray() ?? Array.Empty<float>();
+            var paceFlagsArr    = GetSdkArray<int>(d, "CarIdxPaceFlags")?.Select(v => v ?? 0).ToArray() ?? Array.Empty<int>();
+            var paceLineArr     = GetSdkArray<int>(d, "CarIdxPaceLine")?.Select(v => v ?? 0).ToArray() ?? Array.Empty<int>();
+            var paceRowArr      = GetSdkArray<int>(d, "CarIdxPaceRow")?.Select(v => v ?? 0).ToArray() ?? Array.Empty<int>();
+            var surfMatArr      = GetSdkArray<int>(d, "CarIdxTrackSurfaceMaterial")?.Select(v => v ?? 0).ToArray() ?? Array.Empty<int>();
             int myIdx           = GetSdkValue<int>(d, "PlayerCarIdx") ?? -1;
 
             if (myIdx >= 0 && myIdx < lapPctArr.Length && lapPctArr.Length == posArr.Length)
@@ -248,6 +277,12 @@ namespace SuperBackendNR85IA.Services
                 t.CarIdxLastLapTime = lastLapArr;
                 t.CarIdxBestLapTime = bestLapArr;
                 t.CarIdxF2Time      = f2TimeArr;
+                t.CarIdxGear        = gearArr;
+                t.CarIdxRPM         = rpmArr;
+                t.CarIdxPaceFlags   = paceFlagsArr;
+                t.CarIdxPaceLine    = paceLineArr;
+                t.CarIdxPaceRow     = paceRowArr;
+                t.CarIdxTrackSurfaceMaterial = surfMatArr;
             }
             else
             {
@@ -261,6 +296,12 @@ namespace SuperBackendNR85IA.Services
                 t.CarIdxLastLapTime= Array.Empty<float>();
                 t.CarIdxBestLapTime= Array.Empty<float>();
                 t.CarIdxF2Time     = Array.Empty<float>();
+                t.CarIdxGear       = Array.Empty<int>();
+                t.CarIdxRPM        = Array.Empty<float>();
+                t.CarIdxPaceFlags  = Array.Empty<int>();
+                t.CarIdxPaceLine   = Array.Empty<int>();
+                t.CarIdxPaceRow    = Array.Empty<int>();
+                t.CarIdxTrackSurfaceMaterial = Array.Empty<int>();
             }
         }
 
@@ -284,6 +325,14 @@ namespace SuperBackendNR85IA.Services
             t.Session.PlayerCarIdx      = GetSdkValue<int>(d, "PlayerCarIdx") ?? -1;
             t.Session.TotalLaps         = GetSdkValue<int>(d, "CurrentSessionTotalLaps") ?? -1;
             t.Session.LapsRemainingRace = GetSdkValue<int>(d, "LapsRemainingRace") ?? 0;
+            t.Session.SessionTimeTotal  = GetSdkValue<float>(d, "SessionTimeTotal") ?? 0f;
+            t.Session.SessionLapsTotal  = GetSdkValue<int>(d, "SessionLapsTotal") ?? 0;
+            t.Session.SessionLapsRemain = GetSdkValue<int>(d, "SessionLapsRemain") ?? 0;
+            t.Session.RaceLaps         = GetSdkValue<int>(d, "RaceLaps") ?? 0;
+            t.Session.PitsOpen         = GetSdkValue<bool>(d, "PitsOpen") ?? false;
+            t.Session.SessionUniqueID  = GetSdkValue<long>(d, "SessionUniqueID") ?? 0;
+            t.Session.SessionTick      = GetSdkValue<int>(d, "SessionTick") ?? 0;
+            t.Session.SessionOnJokerLap = GetSdkValue<bool>(d, "SessionOnJokerLap") ?? false;
         }
 
         private void PopulateTyres(IRacingSdkData d, TelemetryModel t)
@@ -398,6 +447,17 @@ namespace SuperBackendNR85IA.Services
             t.TrackSurfaceMaterial = GetSdkValue<int>(d, "TrackSurfaceMaterial") ?? 0;
             t.TrackGripStatus  = GetSdkString(d, "TrackGripStatus") ?? string.Empty;
             t.TrackWetnessPCA  = GetSdkValue<float>(d, "TrackWetness") ?? 0f;
+            t.AirTemp         = GetSdkValue<float>(d, "AirTemp") ?? 0f;
+            t.TrackAltitude   = GetSdkValue<float>(d, "Alt") ?? 0f;
+            t.TrackLatitude   = GetSdkValue<float>(d, "Lat") ?? 0f;
+            t.TrackLongitude  = GetSdkValue<float>(d, "Lon") ?? 0f;
+            t.AirDensity       = GetSdkValue<float>(d, "AirDensity") ?? 0f;
+            t.FogLevel         = GetSdkValue<float>(d, "FogLevel") ?? 0f;
+            t.Precipitation    = GetSdkValue<float>(d, "Precipitation") ?? 0f;
+            t.WeatherDeclaredWet = GetSdkValue<bool>(d, "WeatherDeclaredWet") ?? false;
+            t.SolarAltitude    = GetSdkValue<float>(d, "SolarAltitude") ?? 0f;
+            t.SolarAzimuth     = GetSdkValue<float>(d, "SolarAzimuth") ?? 0f;
+            t.CarLeftRight     = GetSdkString(d, "CarLeftRight") ?? string.Empty;
             t.TrackStatus      = string.Join(", ", EnumTranslations.TranslateSessionFlags(t.SessionFlags));
 
             t.FuelUsePerHour = GetSdkValue<float>(d, "FuelUsePerHour") ?? 0f;

--- a/telemetry-frontend/public/overlays/overlay-radar.html
+++ b/telemetry-frontend/public/overlays/overlay-radar.html
@@ -185,11 +185,17 @@ function CarDot({car}) {
 function RadarOverlay() {
   const [cars, setCars] = React.useState([]);
   React.useEffect(() => {
-    window.updateRadar = (d) => setCars(processarDadosWs(d));
+    window.updateRadar = (d) => {
+      setCars(processarDadosWs(d));
+      const msg = d.carLeftRight ?? '';
+      const el = document.getElementById('left-right-msg');
+      if (el) el.textContent = msg;
+    };
   }, []);
   return (
     <div className="radar">
       <div className="player" />
+      <div id="left-right-msg" style="position:absolute;top:5px;left:50%;transform:translateX(-50%);color:#fff;font-size:1.2rem;"></div>
       {cars.map(c => <CarDot key={c.id} car={c} />)}
     </div>
   );

--- a/telemetry-frontend/public/overlays/overlay-sessao.html
+++ b/telemetry-frontend/public/overlays/overlay-sessao.html
@@ -352,6 +352,12 @@
               <span class="data-label">Vento Dir.:</span><span class="data-value" id="wind-direction" title="WindDir / windDir (YAML)"> —</span>
               <span class="data-label">Umidade Rel.:</span><span class="data-value" id="relative-humidity" title="RelativeHumidity / relativeHumidity (YAML)"> —</span>
               <span class="data-label">Pressão Ar:</span><span class="data-value" id="air-pressure" title="AirPressure / airPressure (YAML)"> —</span>
+              <span class="data-label">Densidade Ar:</span><span class="data-value" id="air-density" title="AirDensity / airDensity (SDK)"> —</span>
+              <span class="data-label">Névoa (%):</span><span class="data-value" id="fog-level" title="FogLevel / fogLevel (SDK)"> —</span>
+              <span class="data-label">Precip. (%):</span><span class="data-value" id="precipitation" title="Precipitation / precipitation (SDK)"> —</span>
+              <span class="data-label">Pista Molhada:</span><span class="data-value" id="weather-wet" title="WeatherDeclaredWet / weatherDeclaredWet (SDK)"> —</span>
+              <span class="data-label">Sol Alt.:</span><span class="data-value" id="solar-altitude" title="SolarAltitude / solarAltitude (SDK)"> —</span>
+              <span class="data-label">Sol Azim.:</span><span class="data-value" id="solar-azimuth" title="SolarAzimuth / solarAzimuth (SDK)"> —</span>
               <span class="data-label">Chuva (%):</span><span class="data-value" id="rain-chance" title="ChanceOfRain / chanceOfRain (YAML)"> —</span> <span class="data-label">Hora Sim.:</span><span class="data-value" id="session-time-of-day" title="SessionTimeOfDay / sessionTimeOfDay (SDK)"> —</span>
             </div>
           </div>
@@ -375,6 +381,7 @@
             <div class="data-grid">
               <span class="data-label">Bandeira:</span><span class="data-value"><span id="flag-status" class="flag-status-span flag-default" title="SessionFlags / sessionFlags (traduzido)"><span>&nbsp;</span></span></span>
               <span class="data-label">Modo Pace Car:</span><span class="data-value" id="pace-car-mode" title="PaceMode / paceMode (traduzido)">—</span>
+              <span class="data-label">Carros L/R:</span><span class="data-value" id="car-left-right" title="CarLeftRight / carLeftRight">—</span>
             </div>
           </div>
 
@@ -651,6 +658,12 @@
         updateText('#wind-direction', d.windDir, wd => `${(wd ?? 0).toFixed(1)} rad`); // YAML WindDir
         updateText('#relative-humidity', d.relativeHumidity, rh => fmtPercentage(rh, 1, false)); // YAML RelativeHumidity (não é fração)
         updateText('#air-pressure', d.airPressure, ap => `${(ap ?? 0).toFixed(2)} kPa`); // YAML AirPressure
+        updateText('#air-density', d.airDensity, ad => `${(ad ?? 0).toFixed(3)} kg/m³`); // SDK AirDensity
+        updateText('#fog-level', d.fogLevel, fl => fmtPercentage(fl, 0, false)); // SDK FogLevel
+        updateText('#precipitation', d.precipitation, p => fmtPercentage(p, 0, false)); // SDK Precipitation
+        updateText('#weather-wet', d.weatherDeclaredWet, w => w ? 'Sim' : 'Não'); // SDK WeatherDeclaredWet
+        updateText('#solar-altitude', d.solarAltitude, sa => `${(sa ?? 0).toFixed(1)}°`); // SDK SolarAltitude
+        updateText('#solar-azimuth', d.solarAzimuth, sa => `${(sa ?? 0).toFixed(1)}°`); // SDK SolarAzimuth
         updateText('#rain-chance', d.chanceOfRain, cr => fmtPercentage(cr, 0, false)); // YAML ChanceOfRain (não é fração)
         updateText('#session-time-of-day', d.sessionTimeOfDay, fmtTimeOfDay); // SDK SessionTimeOfDay
 
@@ -680,6 +693,7 @@
         const paceModeTranslated = translatePaceMode(d.paceMode);
         updateText('#pace-car-mode', paceModeTranslated, null);
         q('#pace-car-mode').setAttribute('title', `PaceMode: ${d.paceMode} (traduzido)`);
+        updateText('#car-left-right', d.carLeftRight);
 
 
         // --- Setores (lógica de nova-tester) ---


### PR DESCRIPTION
## Summary
- extend VehicleData with damper, torque, ERS energy, and boost fields
- expose new session info and arrays for car pace data in TelemetryModel
- pull the additional values from the iRacing SDK

## Testing
- `dotnet build backend/SuperBackendNR85IA.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684af5b99bc483308af509ecaf61a193