### PR TITLE
Fix ambient temperature fallback

### DIFF
--- a/backend/Services/IRacingTelemetryService.AllExtras.cs
+++ b/backend/Services/IRacingTelemetryService.AllExtras.cs
@@ -72,7 +72,7 @@ namespace SuperBackendNR85IA.Services
 
         private void PopulateSessionEnvironmentData(IRacingSdkData d, TelemetryModel t)
         {
-            t.Session.SessionUniqueID = GetSdkValue<int>(d, "SessionUniqueID") ?? 0;
+            t.Session.SessionUniqueID = GetSdkValue<long>(d, "SessionUniqueID") ?? 0;
             t.Session.SessionTick = GetSdkValue<int>(d, "SessionTick") ?? 0;
             t.Session.SessionTimeTotal = GetSdkValue<float>(d, "SessionTimeTotal") ?? 0f;
             t.Environment.WeatherDeclaredWet = GetSdkValue<bool>(d, "WeatherDeclaredWet") ?? false;

--- a/backend/Services/IRacingTelemetryService.Data.cs
+++ b/backend/Services/IRacingTelemetryService.Data.cs
@@ -20,6 +20,7 @@ namespace SuperBackendNR85IA.Services
                 object? value = null;
                 if (typeof(T) == typeof(float)) value = data.GetFloat(datum);
                 else if (typeof(T) == typeof(int)) value = data.GetInt(datum);
+                else if (typeof(T) == typeof(long)) value = (long)data.GetInt(datum);
                 else if (typeof(T) == typeof(bool)) value = data.GetBool(datum);
                 else if (typeof(T) == typeof(double)) value = data.GetDouble(datum);
                 else

--- a/telemetry-frontend/public/overlays/overlay-relative.html
+++ b/telemetry-frontend/public/overlays/overlay-relative.html
@@ -495,8 +495,12 @@ function renderRelative(data) {
   // === Update Header and Footer ===
   document.getElementById('raceName').textContent = `Race: ${data.trackDisplayName || weekendInfo.trackDisplayName || '--'}`;
   document.getElementById('raceTime').textContent = `Sim: ${fmtTimeSimple(data.sessionTime, false) || '00:00'}`;
-  const amb = typeof data.trackAirTemp === 'number' ? data.trackAirTemp
-               : (typeof data.tempValue === 'number' ? data.tempValue : undefined);
+  let amb = undefined;
+  if (typeof data.trackAirTemp === 'number' && data.trackAirTemp > 0) {
+      amb = data.trackAirTemp;
+  } else if (typeof data.tempValue === 'number' && data.tempValue > 0) {
+      amb = data.tempValue;
+  }
   document.getElementById('ambientTemp').textContent = `${typeof amb === 'number' ? amb.toFixed(1) : '--'}`;
   
   let trackTempValue = '--';

--- a/telemetry-frontend/public/overlays/overlaybase.html
+++ b/telemetry-frontend/public/overlays/overlaybase.html
@@ -150,7 +150,13 @@
         document.getElementById('raceTime').textContent = fmtTime(t);
       }
 
-      const ambient = data.trackAirTemp ?? data.weekendInfo?.trackAirTemp;
+      let ambient = undefined;
+      if (typeof data.trackAirTemp === 'number' && data.trackAirTemp > 0) {
+        ambient = data.trackAirTemp;
+      } else if (typeof data.weekendInfo?.trackAirTemp === 'number' &&
+                 data.weekendInfo.trackAirTemp > 0) {
+        ambient = data.weekendInfo.trackAirTemp;
+      }
       if (ambient !== undefined) {
         document.getElementById('ambientTemp').textContent = Math.round(ambient);
       }


### PR DESCRIPTION
## Summary
- handle invalid `trackAirTemp` values when updating overlays
- add support for long values in telemetry service

## Testing
- `npm test --prefix telemetry-frontend`


------
https://chatgpt.com/codex/tasks/task_e_684b9ab298688330bd2d75d9f90ec51f