### PR TITLE
Improve SessionTime logging and precision

### DIFF
--- a/backend/Models/SessionData.cs
+++ b/backend/Models/SessionData.cs
@@ -3,7 +3,7 @@ namespace SuperBackendNR85IA.Models
     public record SessionData
     {
         public int SessionNum { get; set; }
-        public float SessionTime { get; set; }
+        public double SessionTime { get; set; }
         public float SessionTimeRemain { get; set; }
         public int SessionState { get; set; }
         public int PaceMode { get; set; }

--- a/backend/Models/TelemetryModel.cs
+++ b/backend/Models/TelemetryModel.cs
@@ -13,7 +13,7 @@ namespace SuperBackendNR85IA.Models
         // Wrapper properties to keep legacy flat structure
         // ---- Session ----
         public int SessionNum { get => Session.SessionNum; set => Session.SessionNum = value; }
-        public float SessionTime { get => Session.SessionTime; set => Session.SessionTime = value; }
+        public double SessionTime { get => Session.SessionTime; set => Session.SessionTime = value; }
         public float SessionTimeRemain { get => Session.SessionTimeRemain; set => Session.SessionTimeRemain = value; }
         public int SessionState { get => Session.SessionState; set => Session.SessionState = value; }
         public int PaceMode { get => Session.PaceMode; set => Session.PaceMode = value; }
@@ -307,9 +307,9 @@ namespace SuperBackendNR85IA.Models
         public string SessionInfoYaml { get; set; } = string.Empty;
         public List<ResultPosition> Results { get; set; } = new();
 
-        public static string FormatTime(float seconds)
+        public static string FormatTime(double seconds)
         {
-            if (float.IsNaN(seconds) || float.IsInfinity(seconds) || seconds < 0 || seconds > 60 * 60 * 24 * 365)
+            if (double.IsNaN(seconds) || double.IsInfinity(seconds) || seconds < 0 || seconds > 60 * 60 * 24 * 365)
                 return "--:--:--";
             TimeSpan t = TimeSpan.FromSeconds(seconds);
             return $"{(int)t.TotalHours:D2}:{t.Minutes:D2}:{t.Seconds:D2}";

--- a/backend/Services/IRacingTelemetryService.Data.cs
+++ b/backend/Services/IRacingTelemetryService.Data.cs
@@ -309,7 +309,9 @@ namespace SuperBackendNR85IA.Services
         private void PopulateSessionInfo(IRacingSdkData d, TelemetryModel t)
         {
             t.Session.SessionNum        = GetSdkValue<int>(d, "SessionNum") ?? 0;
-            t.Session.SessionTime       = GetSdkValue<float>(d, "SessionTime") ?? 0f;
+            double rawSessionTime = GetSdkValue<double>(d, "SessionTime") ?? 0.0;
+            _log.LogInformation($"Raw SessionTime: {rawSessionTime}");
+            t.Session.SessionTime       = rawSessionTime;
             t.Session.SessionTimeRemain = GetSdkValue<float>(d, "SessionTimeRemain") ?? 0f;
             if (t.SessionNum != _lastSessionNum)
             {


### PR DESCRIPTION
## Summary
- add logging for raw `SessionTime`
- switch `SessionTime` to `double`
- update helper method to accept `double`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684da788c36c8330bad56c30cb342fe5