### PR TITLE
Fix build error due to missing brace

### DIFF
--- a/backend/Services/IRacingTelemetryService.Data.cs
+++ b/backend/Services/IRacingTelemetryService.Data.cs
@@ -314,6 +314,7 @@ namespace SuperBackendNR85IA.Services
             {
                 _log.LogWarning($"Negative SessionTime received: {rawSessionTime}");
                 rawSessionTime = 0.0;
+            }
 
             _log.LogInformation($"Raw SessionTime: {rawSessionTime}");
             t.Session.SessionTime       = rawSessionTime;


### PR DESCRIPTION
## Summary
- fix missing closing brace in `PopulateSessionInfo` to allow build

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dba70683883308c38d145f8b2bb8e