### PR TITLE
Fix negative session remain

### DIFF
--- a/backend/Services/IRacingTelemetryService.Data.cs
+++ b/backend/Services/IRacingTelemetryService.Data.cs
@@ -318,7 +318,13 @@ namespace SuperBackendNR85IA.Services
 
             _log.LogInformation($"Raw SessionTime: {rawSessionTime}");
             t.Session.SessionTime       = rawSessionTime;
-            t.Session.SessionTimeRemain = GetSdkValue<float>(d, "SessionTimeRemain") ?? 0f;
+            float rawRemain = GetSdkValue<float>(d, "SessionTimeRemain") ?? 0f;
+            if (rawRemain < 0)
+            {
+                _log.LogWarning($"Negative SessionTimeRemain received: {rawRemain}");
+                rawRemain = 0f;
+            }
+            t.Session.SessionTimeRemain = rawRemain;
             if (t.SessionNum != _lastSessionNum)
             {
                 _lastSessionNum = t.Session.SessionNum;


### PR DESCRIPTION
## Summary
- sanitize SessionTimeRemain so negative values clamp to zero

## Testing
- `dotnet build backend/SuperBackendNR85IA.csproj -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684dbda5df108330880cad4a5c0ab871