### PR TITLE
Fix backend tire data fields

### DIFF
--- a/backend/Models/TelemetryCalculationsOverlay.cs
+++ b/backend/Models/TelemetryCalculationsOverlay.cs
@@ -31,6 +31,9 @@ namespace SuperBackendNR85IA.Calculations
 
         public static void PreencherOverlayPneus(ref TelemetryModel model)
         {
+            model.Tyres.Compound = string.IsNullOrEmpty(model.Tyres.Compound)
+                ? model.TireCompound
+                : model.Tyres.Compound;
             model.Tyres.LfWear ??= new float[3];
             model.Tyres.RfWear ??= new float[3];
             model.Tyres.LrWear ??= new float[3];

--- a/backend/Models/TelemetryModel.cs
+++ b/backend/Models/TelemetryModel.cs
@@ -199,6 +199,7 @@ namespace SuperBackendNR85IA.Models
         public string[] CarIdxCarClassShortNames { get; set; } = Array.Empty<string>();
         public float[] CarIdxCarClassEstLapTimes { get; set; } = Array.Empty<float>();
         public string[] CarIdxTireCompounds { get; set; } = Array.Empty<string>();
+        public string TireCompound { get; set; } = string.Empty;
         public int[] CarIdxGear { get; set; } = Array.Empty<int>();
         public float[] CarIdxRPM { get; set; } = Array.Empty<float>();
         public int[] CarIdxPaceFlags { get; set; } = Array.Empty<int>();

--- a/backend/Models/TyreData.cs
+++ b/backend/Models/TyreData.cs
@@ -75,6 +75,9 @@ namespace SuperBackendNR85IA.Models
         public float FrontStagger { get; set; }
         public float RearStagger { get; set; }
 
+        // Current tire compound for the player's car (from YAML)
+        public string Compound { get; set; } = string.Empty;
+
         public float TreadRemainingFl { get; set; }
         public float TreadRemainingFr { get; set; }
         public float TreadRemainingRl { get; set; }

--- a/backend/Services/IRacingTelemetryService.Data.cs
+++ b/backend/Services/IRacingTelemetryService.Data.cs
@@ -527,6 +527,8 @@ namespace SuperBackendNR85IA.Services
                 t.LicString          = drv.LicString;
                 t.LicSafetyRating    = drv.LicLevel + drv.LicSubLevel / 1000f;
                 t.PlayerCarClassID   = drv.CarClassID;
+                t.TireCompound       = drv.TireCompound;
+                t.Tyres.Compound     = drv.TireCompound;
             }
             t.PlayerCarTeamIncidentCount = GetSdkValue<int>(d, "PlayerCarTeamIncidentCount") ?? 0;
             t.PlayerCarMyIncidentCount   = GetSdkValue<int>(d, "PlayerCarMyIncidentCount") ?? 0;

--- a/backend/Services/IRacingTelemetryService.DriverArrays.cs
+++ b/backend/Services/IRacingTelemetryService.DriverArrays.cs
@@ -30,6 +30,11 @@ namespace SuperBackendNR85IA.Services
                 var classShort = t.CarIdxCarClassShortNames; Resize(ref classShort);   classShort[d.CarIdx] = d.CarClassShortName; t.CarIdxCarClassShortNames = classShort;
                 var estTimes = t.CarIdxCarClassEstLapTimes; Resize(ref estTimes);      estTimes[d.CarIdx] = d.CarClassEstLapTime; t.CarIdxCarClassEstLapTimes = estTimes;
                 var compounds = t.CarIdxTireCompounds;     Resize(ref compounds);       compounds[d.CarIdx] = d.TireCompound;     t.CarIdxTireCompounds = compounds;
+                if (d.CarIdx == t.PlayerCarIdx)
+                {
+                    t.TireCompound   = d.TireCompound;
+                    t.Tyres.Compound = d.TireCompound;
+                }
 
                 var irDeltas = t.CarIdxIRatingDeltas;      Resize(ref irDeltas);        if (_irStart.Length <= d.CarIdx) Array.Resize(ref _irStart, d.CarIdx + 1);
                 if (_irStart[d.CarIdx] == 0) _irStart[d.CarIdx] = d.IRating;           irDeltas[d.CarIdx] = d.IRating - _irStart[d.CarIdx];

--- a/backend/Services/IRacingTelemetryService.cs
+++ b/backend/Services/IRacingTelemetryService.cs
@@ -203,6 +203,19 @@ namespace SuperBackendNR85IA.Services
                 _rrColdTempCm = t.RrTempCm;
                 _rrColdTempCr = t.RrTempCr;
             }
+            else
+            {
+                // Valores iniciais caso o serviço seja iniciado no meio da pista
+                if (_lfColdPress == 0f) _lfColdPress = t.LfPress;
+                if (_rfColdPress == 0f) _rfColdPress = t.RfPress;
+                if (_lrColdPress == 0f) _lrColdPress = t.LrPress;
+                if (_rrColdPress == 0f) _rrColdPress = t.RrPress;
+
+                if (_lfLastHotPress == 0f && t.OnPitRoad) _lfLastHotPress = t.LfPress;
+                if (_rfLastHotPress == 0f && t.OnPitRoad) _rfLastHotPress = t.RfPress;
+                if (_lrLastHotPress == 0f && t.OnPitRoad) _lrLastHotPress = t.LrPress;
+                if (_rrLastHotPress == 0f && t.OnPitRoad) _rrLastHotPress = t.RrPress;
+            }
             _wasOnPitRoad = t.OnPitRoad;
 
             t.LfColdPress = _lfColdPress;

--- a/telemetry-frontend/public/overlays/overlay-tiresgarage.html
+++ b/telemetry-frontend/public/overlays/overlay-tiresgarage.html
@@ -739,9 +739,12 @@
       // Update wear percentages
       const wearData = tireData.treadRemaining || tireData.wear ||
             { left:0, middle:0, right:0 };
-      getTireElement(tireId, 'wearL').textContent = `${(wearData.left * 100).toFixed(1)}%`;
-      getTireElement(tireId, 'wearM').textContent = `${(wearData.middle * 100).toFixed(1)}%`;
-      getTireElement(tireId, 'wearR').textContent = `${(wearData.right * 100).toFixed(1)}%`;
+
+      const fmtWear = v => (v > 1 ? v : v * 100).toFixed(1);
+
+      getTireElement(tireId, 'wearL').textContent = `${fmtWear(wearData.left)}%`;
+      getTireElement(tireId, 'wearM').textContent = `${fmtWear(wearData.middle)}%`;
+      getTireElement(tireId, 'wearR').textContent = `${fmtWear(wearData.right)}%`;
 
       // Update temperatures and apply color classes
       const tempL_el = getTireElement(tireId, 'tempL');
@@ -776,7 +779,7 @@
       // Update final pressure
       const hotVal = tireData.lastHotPressure ?? tireData.pressure ?? 0;
 
-      const coldVal = tireData.coldPressure ?? tireData.startPress ?? tireData.pressure ?? 0;
+      const coldVal = tireData.coldPressure ?? tireData.pressure ?? 0;
       getTireElement(tireId, 'hot').textContent = `${hotVal.toFixed(1)} psi`;
       getTireElement(tireId, 'press').textContent = `${coldVal.toFixed(1)} psi`;
 
@@ -799,11 +802,11 @@
     function handleData(d) {
         d = { ...d, ...(d.tyres || d.tires || {}) };
 
+        const src = d.tyres || d.tires || d;
         let tires = d.tyres || d.tires;
         const hasNested = tires && typeof tires.frontLeft === 'object';
 
         if (!hasNested) {
-            const src = d.tyres || d.tires || d;
             const compArr = d.carIdxTireCompounds || d.carIdxTireCompound;
             const comp = Array.isArray(compArr) && typeof d.playerCarIdx === 'number'
                 ? (compArr[d.playerCarIdx] || 'U')


### PR DESCRIPTION
## Summary
- add compound info to tire data
- expose TireCompound in TelemetryModel
- populate compound from YAML
- track player compound in driver array handler
- better initialization of hot/cold tire pressures

## Testing
- `npm test --prefix telemetry-frontend`
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dd1a3ec0c8330a22d805d50f61e4a