### PR TITLE
Include tire compound fields in example message

### DIFF
--- a/ws/messages/overlay_message.json
+++ b/ws/messages/overlay_message.json
@@ -21,6 +21,8 @@
     "Soft",
     "Soft"
   ],
+  "tireCompound": "Soft",
+  "compound": "Soft",
   "lfTempCl": 80.0,
   "lfTempCm": 85.0,
   "lfTempCr": 90.0,


### PR DESCRIPTION
## Summary
- ensure `tireCompound` and `compound` appear in sample WebSocket payload

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684deb35df00833089a34880ae1cffab