### PR TITLE
Remove deprecated energy & boost fields

### DIFF
--- a/backend/Models/VehicleData.cs
+++ b/backend/Models/VehicleData.cs
@@ -39,16 +39,10 @@ namespace SuperBackendNR85IA.Models
         public float PitchRate { get; set; }
         public float RollRate { get; set; }
 
-        // Additional dynamics and energy systems
+        // Additional dynamics
         public float SteeringWheelPctDamper { get; set; }
         public float SteeringWheelPctTorque { get; set; }
         public float SteeringWheelPctTorqueSign { get; set; }
         public float SteeringWheelPctTorqueSignStops { get; set; }
-        public float EnergyERSBattery { get; set; }
-        public float EnergyERSBatteryPct { get; set; }
-        public float EnergyMGU_KLapDeployPct { get; set; }
-        public float EnergyBatteryToMGU_KLap { get; set; }
-        public bool ManualBoost { get; set; }
-        public bool ManualNoBoost { get; set; }
     }
 }

--- a/backend/Services/IRacingTelemetryService.Data.cs
+++ b/backend/Services/IRacingTelemetryService.Data.cs
@@ -143,12 +143,12 @@ namespace SuperBackendNR85IA.Services
             t.Vehicle.SteeringWheelPctTorque = GetSdkValue<float>(d, "SteeringWheelPctTorque") ?? 0f;
             t.Vehicle.SteeringWheelPctTorqueSign = GetSdkValue<float>(d, "SteeringWheelPctTorqueSign") ?? 0f;
             t.Vehicle.SteeringWheelPctTorqueSignStops = GetSdkValue<float>(d, "SteeringWheelPctTorqueSignStops") ?? 0f;
-            t.Vehicle.EnergyERSBattery        = GetSdkValue<float>(d, "EnergyERSBattery") ?? 0f;
-            t.Vehicle.EnergyERSBatteryPct     = GetSdkValue<float>(d, "EnergyERSBatteryPct") ?? 0f;
-            t.Vehicle.EnergyMGU_KLapDeployPct = GetSdkValue<float>(d, "EnergyMGU_KLapDeployPct") ?? 0f;
-            t.Vehicle.EnergyBatteryToMGU_KLap = GetSdkValue<float>(d, "EnergyBatteryToMGU_KLap") ?? 0f;
-            t.Vehicle.ManualBoost             = GetSdkValue<bool>(d, "ManualBoost") ?? false;
-            t.Vehicle.ManualNoBoost           = GetSdkValue<bool>(d, "ManualNoBoost") ?? false;
+            t.Powertrain.EnergyErsBattery        = GetSdkValue<float>(d, "EnergyERSBattery") ?? 0f;
+            t.Powertrain.EnergyErsBatteryPct     = GetSdkValue<float>(d, "EnergyERSBatteryPct") ?? 0f;
+            t.Powertrain.EnergyMguKLapDeployPct  = GetSdkValue<float>(d, "EnergyMGU_KLapDeployPct") ?? 0f;
+            t.Powertrain.EnergyBatteryToMguKLap  = GetSdkValue<float>(d, "EnergyBatteryToMGU_KLap") ?? 0f;
+            t.Powertrain.ManualBoost             = GetSdkValue<bool>(d, "ManualBoost") ?? false;
+            t.Powertrain.ManualNoBoost           = GetSdkValue<bool>(d, "ManualNoBoost") ?? false;
         }
 
         private void UpdateLapInfo(IRacingSdkData d, TelemetryModel t)


### PR DESCRIPTION
## Summary
- streamline `VehicleData` by dropping obsolete energy/boost fields
- capture energy/boost data via `TelemetryModel.Powertrain`

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df17a88988330a9520de4f39224ea