### PR TITLE
Improve fuel calc validation and logging

### DIFF
--- a/backend/Services/IRacingTelemetryService.cs
+++ b/backend/Services/IRacingTelemetryService.cs
@@ -74,6 +74,7 @@ namespace SuperBackendNR85IA.Services
             CarTrackDataStore store)
         {
             _log = log;
+            TelemetryCalculations.SetLogger(log);
             _broadcaster = broadcaster;
             _store = store;
         }
@@ -116,8 +117,6 @@ namespace SuperBackendNR85IA.Services
                             TelemetryCalculationsOverlay.PreencherOverlayPneus(ref telemetryModel);
                             TelemetryCalculationsOverlay.PreencherOverlaySetores(ref telemetryModel);
                             TelemetryCalculationsOverlay.PreencherOverlayDelta(ref telemetryModel);
-
-                            TelemetryCalculations.SanitizeModel(telemetryModel);
 
                             await _broadcaster.BroadcastTelemetry(telemetryModel);
                         }


### PR DESCRIPTION
## Summary
- add logger support and validation helpers to `TelemetryCalculations`
- validate results in `CalculateFuelPerLap` and fuel update logic
- remove call to `SanitizeModel` and wire logger

## Testing
- `dotnet build` *(fails: command not found)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684df18038f883308fbdfaa27c0b3cfa