### PR TITLE
Fix parsing regex and log message

### DIFF
--- a/backend/Services/IRacingTelemetryService.cs
+++ b/backend/Services/IRacingTelemetryService.cs
@@ -159,7 +159,6 @@ namespace SuperBackendNR85IA.Services
                 $"Temps LF:{t.LfTempCl}/{t.LfTempCm}/{t.LfTempCr} RF:{t.RfTempCl}/{t.RfTempCm}/{t.RfTempCr} " +
                 $"LR:{t.LrTempCl}/{t.LrTempCm}/{t.LrTempCr} RR:{t.RrTempCl}/{t.RrTempCm}/{t.RrTempCr}, " +
                 $"Tread FL:{t.TreadRemainingFl} FR:{t.TreadRemainingFr} RL:{t.TreadRemainingRl} RR:{t.TreadRemainingRr}");
-                $"Tread FL:{t.TreadRemainingFl} FR:{t.TreadRemainingFr} RL:{t.TreadRemainingRl} RR:{t.TreadRemainingRr}");
             UpdateLastHotPress(t);
             await ApplyYamlData(d, t);
             RunCustomCalculations(d, t);

--- a/backend/Services/SessionYamlParser.cs
+++ b/backend/Services/SessionYamlParser.cs
@@ -266,7 +266,7 @@ namespace SuperBackendNR85IA.Services
             string rawValue = GetStr(n, key); // GetStr logs missing key
             if (!string.IsNullOrEmpty(rawValue))
             {
-                var match = Regex.Match(rawValue, "[-+]?[0-9]*\.?[0-9]+");
+                var match = Regex.Match(rawValue, @"[-+]?[0-9]*\.?[0-9]+");
                 if (match.Success && float.TryParse(match.Value, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out float result))
                 {
                     return result;


### PR DESCRIPTION
## Summary
- fix regex escape handling for float parsing
- remove stray duplicate log message in telemetry service

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df439669c8330856a93f5d62e6604