### PR TITLE
Add telemetry variable logging

### DIFF
--- a/backend/Services/IRacingTelemetryService.Data.cs
+++ b/backend/Services/IRacingTelemetryService.Data.cs
@@ -14,8 +14,12 @@ namespace SuperBackendNR85IA.Services
         {
             try
             {
-                if (!data.TelemetryDataProperties.TryGetValue(varName, out var datum)) return null;
-                if (datum.Count == 0) return null;
+                if (!data.TelemetryDataProperties.TryGetValue(varName, out var datum) || datum.Count == 0)
+                {
+                    if (_missingVarWarned.Add(varName))
+                        _log.LogWarning($"Campo {varName} não está disponível no SDK.");
+                    return null;
+                }
 
                 object? value = null;
                 if (typeof(T) == typeof(float)) value = data.GetFloat(datum);
@@ -41,8 +45,12 @@ namespace SuperBackendNR85IA.Services
         {
             try
             {
-                if (!data.TelemetryDataProperties.TryGetValue(varName, out var datum)) return null;
-                if (datum.Count == 0) return null;
+                if (!data.TelemetryDataProperties.TryGetValue(varName, out var datum) || datum.Count == 0)
+                {
+                    if (_missingVarWarned.Add(varName))
+                        _log.LogWarning($"Campo {varName} não está disponível no SDK.");
+                    return null;
+                }
                 var value = data.GetValue(datum);
                 if (value is char[] charArray) return new string(charArray).TrimEnd('\0');
                 return value?.ToString()?.TrimEnd('\0');
@@ -60,6 +68,8 @@ namespace SuperBackendNR85IA.Services
             {
                 if (!data.TelemetryDataProperties.TryGetValue(varName, out var datum) || datum.Count == 0)
                 {
+                    if (_missingVarWarned.Add(varName))
+                        _log.LogWarning($"Campo {varName} não está disponível no SDK.");
                     return Array.Empty<T?>();
                 }
 

--- a/backend/Services/IRacingTelemetryService.cs
+++ b/backend/Services/IRacingTelemetryService.cs
@@ -67,6 +67,8 @@ namespace SuperBackendNR85IA.Services
         private float _rrColdTempCl;
         private float _rrColdTempCm;
         private float _rrColdTempCr;
+        private bool _loggedAvailableVars = false;
+        private readonly HashSet<string> _missingVarWarned = new();
 
         public IRacingTelemetryService(
             ILogger<IRacingTelemetryService> log,
@@ -108,6 +110,13 @@ namespace SuperBackendNR85IA.Services
                     {
                         await Task.Delay(1000, ct);
                         continue;
+                    }
+
+                    if (!_loggedAvailableVars && _sdk.Data != null)
+                    {
+                        var available = _sdk.Data.TelemetryDataProperties.Keys;
+                        _log.LogInformation("Variáveis disponíveis no SDK: " + string.Join(", ", available));
+                        _loggedAvailableVars = true;
                     }
 
                     if (_sdk.Data != null && _sdk.Data.TickCount != _lastTick)


### PR DESCRIPTION
## Summary
- log available telemetry variables on startup
- warn if telemetry fields are missing

## Testing
- `npm test --prefix telemetry-frontend` *(fails: No tests configured)*

------
https://chatgpt.com/codex/tasks/task_e_684e1359f3e88330a2e6cae95c5f06be