### PR TITLE
Add raw diagnostic overlay

### DIFF
--- a/telemetry-frontend/public/overlays/overlay-diagnostico-raw.html
+++ b/telemetry-frontend/public/overlays/overlay-diagnostico-raw.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Diagnóstico Raw</title>
+  <style>
+    html,body { margin:0; padding:0; height:100%; background:#111; color:#e2e8f0; font-family: monospace; font-size: 12px; }
+    pre { margin:0; padding:0.5rem; white-space: pre-wrap; word-break: break-all; overflow: auto; height:100%; }
+  </style>
+</head>
+<body>
+<pre id="output">Conectando...</pre>
+<script type="module">
+import { initOverlayWebSocket } from '../overlay-common.js';
+
+const output = document.getElementById('output');
+function handleData(data) {
+  output.textContent = JSON.stringify(data, null, 2);
+}
+initOverlayWebSocket(handleData);
+</script>
+</body>
+</html>

--- a/telemetry-frontend/src/overlayList.js
+++ b/telemetry-frontend/src/overlayList.js
@@ -10,5 +10,6 @@ export default [
   { name: 'Calculadora', file: 'overlay-calculadora.html' },
   { name: 'Tire Wear', file: 'overlay-tirewear.html' },
   { name: 'Base', file: 'overlaybase.html' },
-  { name: 'Teste Final', file: 'overlay-testefinal.html' }
+  { name: 'Teste Final', file: 'overlay-testefinal.html' },
+  { name: 'Diagnóstico Raw', file: 'overlay-diagnostico-raw.html' }
 ];


### PR DESCRIPTION
## Summary
- add a minimal overlay that prints the raw JSON received from the backend
- list the new overlay option in the overlay selection menu

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e23502ef88330ab173caf52e032a5