### PR TITLE
Refatoração de arrays duplicados e limpeza

### DIFF
--- a/backend/Models/TelemetryCalculationsOverlay.cs
+++ b/backend/Models/TelemetryCalculationsOverlay.cs
@@ -46,28 +46,6 @@ namespace SuperBackendNR85IA.Calculations
             model.Tyres.LrTreadRemainingParts ??= model.Tyres.LrWear;
             model.Tyres.RrTreadRemainingParts ??= model.Tyres.RrWear;
 
-            model.Tyres.LfPress = model.Tyres.LfPress;
-            model.Tyres.RfPress = model.Tyres.RfPress;
-            model.Tyres.LrPress = model.Tyres.LrPress;
-            model.Tyres.RrPress = model.Tyres.RrPress;
-
-            model.Tyres.LfColdPress = model.Tyres.LfColdPress;
-            model.Tyres.RfColdPress = model.Tyres.RfColdPress;
-            model.Tyres.LrColdPress = model.Tyres.LrColdPress;
-            model.Tyres.RrColdPress = model.Tyres.RrColdPress;
-
-            model.Tyres.LfColdTempCl = model.Tyres.LfColdTempCl;
-            model.Tyres.LfColdTempCm = model.Tyres.LfColdTempCm;
-            model.Tyres.LfColdTempCr = model.Tyres.LfColdTempCr;
-            model.Tyres.RfColdTempCl = model.Tyres.RfColdTempCl;
-            model.Tyres.RfColdTempCm = model.Tyres.RfColdTempCm;
-            model.Tyres.RfColdTempCr = model.Tyres.RfColdTempCr;
-            model.Tyres.LrColdTempCl = model.Tyres.LrColdTempCl;
-            model.Tyres.LrColdTempCm = model.Tyres.LrColdTempCm;
-            model.Tyres.LrColdTempCr = model.Tyres.LrColdTempCr;
-            model.Tyres.RrColdTempCl = model.Tyres.RrColdTempCl;
-            model.Tyres.RrColdTempCm = model.Tyres.RrColdTempCm;
-            model.Tyres.RrColdTempCr = model.Tyres.RrColdTempCr;
 
             model.Tyres.FrontStagger = (model.RfRideHeight - model.LfRideHeight) * 1000f;
             model.Tyres.RearStagger  = (model.RrRideHeight - model.LrRideHeight) * 1000f;

--- a/backend/Models/TelemetryModel.cs
+++ b/backend/Models/TelemetryModel.cs
@@ -200,12 +200,12 @@ namespace SuperBackendNR85IA.Models
         public string[] CarIdxTireCompounds { get; set; } = Array.Empty<string>();
         public string TireCompound { get; set; } = string.Empty;
         public string Compound { get => Tyres.Compound; set => Tyres.Compound = value; }
-        public int[] CarIdxGear { get; set; } = Array.Empty<int>();
-        public float[] CarIdxRPM { get; set; } = Array.Empty<float>();
-        public int[] CarIdxPaceFlags { get; set; } = Array.Empty<int>();
-        public int[] CarIdxPaceLine { get; set; } = Array.Empty<int>();
-        public int[] CarIdxPaceRow { get; set; } = Array.Empty<int>();
-        public int[] CarIdxTrackSurfaceMaterial { get; set; } = Array.Empty<int>();
+        public int[] CarIdxGear { get => Radar.CarIdxGear; set => Radar.CarIdxGear = value; }
+        public float[] CarIdxRPM { get => Radar.CarIdxRPM; set => Radar.CarIdxRPM = value; }
+        public int[] CarIdxPaceFlags { get => Radar.CarIdxPaceFlags; set => Radar.CarIdxPaceFlags = value; }
+        public int[] CarIdxPaceLine { get => Radar.CarIdxPaceLine; set => Radar.CarIdxPaceLine = value; }
+        public int[] CarIdxPaceRow { get => Radar.CarIdxPaceRow; set => Radar.CarIdxPaceRow = value; }
+        public int[] CarIdxTrackSurfaceMaterial { get => Radar.CarIdxTrackSurfaceMaterial; set => Radar.CarIdxTrackSurfaceMaterial = value; }
         public bool IsMultiClassSession { get; set; }
         public string CarAheadName { get; set; } = string.Empty;
         public string CarBehindName { get; set; } = string.Empty;

--- a/backend/Services/IRacingTelemetryService.Data.cs
+++ b/backend/Services/IRacingTelemetryService.Data.cs
@@ -291,12 +291,12 @@ namespace SuperBackendNR85IA.Services
                 t.CarIdxLastLapTime = lastLapArr;
                 t.CarIdxBestLapTime = bestLapArr;
                 t.CarIdxF2Time      = f2TimeArr;
-                t.CarIdxGear        = gearArr;
-                t.CarIdxRPM         = rpmArr;
-                t.CarIdxPaceFlags   = paceFlagsArr;
-                t.CarIdxPaceLine    = paceLineArr;
-                t.CarIdxPaceRow     = paceRowArr;
-                t.CarIdxTrackSurfaceMaterial = surfMatArr;
+                t.Radar.CarIdxGear        = gearArr;
+                t.Radar.CarIdxRPM         = rpmArr;
+                t.Radar.CarIdxPaceFlags   = paceFlagsArr;
+                t.Radar.CarIdxPaceLine    = paceLineArr;
+                t.Radar.CarIdxPaceRow     = paceRowArr;
+                t.Radar.CarIdxTrackSurfaceMaterial = surfMatArr;
             }
             else
             {
@@ -310,12 +310,12 @@ namespace SuperBackendNR85IA.Services
                 t.CarIdxLastLapTime= Array.Empty<float>();
                 t.CarIdxBestLapTime= Array.Empty<float>();
                 t.CarIdxF2Time     = Array.Empty<float>();
-                t.CarIdxGear       = Array.Empty<int>();
-                t.CarIdxRPM        = Array.Empty<float>();
-                t.CarIdxPaceFlags  = Array.Empty<int>();
-                t.CarIdxPaceLine   = Array.Empty<int>();
-                t.CarIdxPaceRow    = Array.Empty<int>();
-                t.CarIdxTrackSurfaceMaterial = Array.Empty<int>();
+                t.Radar.CarIdxGear       = Array.Empty<int>();
+                t.Radar.CarIdxRPM        = Array.Empty<float>();
+                t.Radar.CarIdxPaceFlags  = Array.Empty<int>();
+                t.Radar.CarIdxPaceLine   = Array.Empty<int>();
+                t.Radar.CarIdxPaceRow    = Array.Empty<int>();
+                t.Radar.CarIdxTrackSurfaceMaterial = Array.Empty<int>();
             }
         }
 


### PR DESCRIPTION
## Summary
- remove self assignments in `PreencherOverlayPneus`
- forward `CarIdxGear` e outros campos para `Radar` evitando duplicidade
- usa essas propriedades atualizadas na coleta de dados

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e2e30c43483308bce4ffdd16b8a4b