### PR TITLE
fix build by removing obsolete SDK flag

### DIFF
--- a/backend/Services/IRacingTelemetryService.cs
+++ b/backend/Services/IRacingTelemetryService.cs
@@ -96,7 +96,7 @@ namespace SuperBackendNR85IA.Services
             {
                 // Habilita todas as variáveis de telemetria, incluindo dados de setup
                 // necessários para pressões frias e desgaste de pneus
-                _sdk.Start(IRSDKSharper.DefinitionFlags.All);
+                _sdk.Start();
                 _log.LogInformation("IRSDKSharper iniciado e aguardando conexão com o iRacing.");
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- remove `DefinitionFlags.All` usage from `IRacingTelemetryService`

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_684e34d6b3d48330b4ea8ed262ac5dd6