### PR TITLE
Sanitize telemetry before broadcasting

### DIFF
--- a/backend/Services/IRacingTelemetryService.cs
+++ b/backend/Services/IRacingTelemetryService.cs
@@ -131,6 +131,7 @@ namespace SuperBackendNR85IA.Services
                             TelemetryCalculationsOverlay.PreencherOverlayPneus(ref telemetryModel);
                             TelemetryCalculationsOverlay.PreencherOverlaySetores(ref telemetryModel);
                             TelemetryCalculationsOverlay.PreencherOverlayDelta(ref telemetryModel);
+                            TelemetryCalculations.SanitizeModel(telemetryModel);
 
                             await _broadcaster.BroadcastTelemetry(telemetryModel);
                         }
@@ -174,6 +175,7 @@ namespace SuperBackendNR85IA.Services
             UpdateLastHotPress(t);
             await ApplyYamlData(d, t);
             RunCustomCalculations(d, t);
+            TelemetryCalculations.SanitizeModel(t);
             await PersistCarTrackData(t);
 
             return t;


### PR DESCRIPTION
## Summary
- sanitize telemetry model after running custom calculations
- sanitize again right before broadcasting

## Testing
- `dotnet build backend/SuperBackendNR85IA.csproj -clp:ErrorsOnly` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684ed6570d5c8330b73bba18deb64b23