### PR TITLE
feat: enable full telemetry definitions

### DIFF
--- a/backend/Services/IRacingTelemetryService.cs
+++ b/backend/Services/IRacingTelemetryService.cs
@@ -96,7 +96,7 @@ namespace SuperBackendNR85IA.Services
             {
                 // Habilita todas as variáveis de telemetria, incluindo dados de setup
                 // necessários para pressões frias e desgaste de pneus
-                _sdk.Start();
+                _sdk.Start(IRSDKSharper.DefinitionFlags.All);
                 _log.LogInformation("IRSDKSharper iniciado e aguardando conexão com o iRacing.");
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- ensure telemetry SDK starts with all definition flags for car setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ed67234dc8330a76ebe6c27187936