### PR TITLE
Add tyre temp status and overlay pill display

### DIFF
--- a/backend/Models/TelemetryCalculations.cs
+++ b/backend/Models/TelemetryCalculations.cs
@@ -381,4 +381,20 @@ namespace SuperBackendNR85IA.Calculations
             }
         }
     }
+
+    public static class TyreHelpers
+    {
+        public enum TempStatus { Cold, Ideal, Warning, Hot }
+
+        public static TempStatus Classify(float temp)
+        {
+            if (temp < 60) return TempStatus.Cold;
+            if (temp <= 85) return TempStatus.Ideal;
+            if (temp <= 105) return TempStatus.Warning;
+            return TempStatus.Hot;
+        }
+
+        public static TempStatus[] ClassifyTriplet(float inT, float midT, float outT)
+            => new[] { Classify(inT), Classify(midT), Classify(outT) };
+    }
 }

--- a/backend/Models/TelemetryCalculationsOverlay.cs
+++ b/backend/Models/TelemetryCalculationsOverlay.cs
@@ -46,6 +46,28 @@ namespace SuperBackendNR85IA.Calculations
             model.Tyres.LrTreadRemainingParts ??= model.Tyres.LrWear;
             model.Tyres.RrTreadRemainingParts ??= model.Tyres.RrWear;
 
+            model.LfTempStatus = new TyreStatus(
+                TyreHelpers.Classify(model.LfTempCl),
+                TyreHelpers.Classify(model.LfTempCm),
+                TyreHelpers.Classify(model.LfTempCr));
+            model.RfTempStatus = new TyreStatus(
+                TyreHelpers.Classify(model.RfTempCl),
+                TyreHelpers.Classify(model.RfTempCm),
+                TyreHelpers.Classify(model.RfTempCr));
+            model.LrTempStatus = new TyreStatus(
+                TyreHelpers.Classify(model.LrTempCl),
+                TyreHelpers.Classify(model.LrTempCm),
+                TyreHelpers.Classify(model.LrTempCr));
+            model.RrTempStatus = new TyreStatus(
+                TyreHelpers.Classify(model.RrTempCl),
+                TyreHelpers.Classify(model.RrTempCm),
+                TyreHelpers.Classify(model.RrTempCr));
+
+            model.TyreStatus = new TyreStatusSet(
+                model.LfTempStatus,
+                model.RfTempStatus,
+                model.LrTempStatus,
+                model.RrTempStatus);
 
             model.Tyres.FrontStagger = (model.RfRideHeight - model.LfRideHeight) * 1000f;
             model.Tyres.RearStagger  = (model.RrRideHeight - model.LrRideHeight) * 1000f;

--- a/backend/Models/TelemetryModel.cs
+++ b/backend/Models/TelemetryModel.cs
@@ -316,6 +316,17 @@ namespace SuperBackendNR85IA.Models
         public string SessionInfoYaml { get; set; } = string.Empty;
         public List<ResultPosition> Results { get; set; } = new();
 
+        public TyreStatus LfTempStatus { get; set; } = new(TyreHelpers.TempStatus.Cold, TyreHelpers.TempStatus.Cold, TyreHelpers.TempStatus.Cold);
+        public TyreStatus RfTempStatus { get; set; } = new(TyreHelpers.TempStatus.Cold, TyreHelpers.TempStatus.Cold, TyreHelpers.TempStatus.Cold);
+        public TyreStatus LrTempStatus { get; set; } = new(TyreHelpers.TempStatus.Cold, TyreHelpers.TempStatus.Cold, TyreHelpers.TempStatus.Cold);
+        public TyreStatus RrTempStatus { get; set; } = new(TyreHelpers.TempStatus.Cold, TyreHelpers.TempStatus.Cold, TyreHelpers.TempStatus.Cold);
+
+        public TyreStatusSet TyreStatus { get; set; } = new(
+            new(TyreHelpers.TempStatus.Cold, TyreHelpers.TempStatus.Cold, TyreHelpers.TempStatus.Cold),
+            new(TyreHelpers.TempStatus.Cold, TyreHelpers.TempStatus.Cold, TyreHelpers.TempStatus.Cold),
+            new(TyreHelpers.TempStatus.Cold, TyreHelpers.TempStatus.Cold, TyreHelpers.TempStatus.Cold),
+            new(TyreHelpers.TempStatus.Cold, TyreHelpers.TempStatus.Cold, TyreHelpers.TempStatus.Cold));
+
         public static string FormatTime(double seconds)
         {
             if (double.IsNaN(seconds) || double.IsInfinity(seconds) || seconds < 0 || seconds > 60 * 60 * 24 * 365)
@@ -330,4 +341,17 @@ namespace SuperBackendNR85IA.Models
         public string Text { get; set; } = string.Empty;
         public string Class { get; set; } = string.Empty;
     }
+
+    public record TyreStatus(
+        TyreHelpers.TempStatus In,
+        TyreHelpers.TempStatus Mid,
+        TyreHelpers.TempStatus Out
+    );
+
+    public record TyreStatusSet(
+        TyreStatus Lf,
+        TyreStatus Rf,
+        TyreStatus Lr,
+        TyreStatus Rr
+    );
 }

--- a/backend/Services/TelemetryBroadcaster.cs
+++ b/backend/Services/TelemetryBroadcaster.cs
@@ -25,6 +25,7 @@ namespace SuperBackendNR85IA.Services
             {
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase
             };
+            _jsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
         }
 
         public async Task AddClient(WebSocket webSocket, CancellationToken cancellationToken)

--- a/telemetry-frontend/public/overlays/overlay-tiresandbrakes.html
+++ b/telemetry-frontend/public/overlays/overlay-tiresandbrakes.html
@@ -215,7 +215,11 @@
           <div class="text-xs text-blue-300">BRAKE</div>
           <div class="brake text-lg font-bold">0.0</div>
           <div class="text-xs text-blue-300">TIRE TEMP</div>
-          <div class="temp text-lg font-bold">0.0°C</div>
+          <div class="temp flex justify-center gap-1">
+            <span class="in px-1 rounded text-xs font-semibold bg-slate-600">-</span>
+            <span class="mid px-1 rounded text-xs font-semibold bg-slate-600">-</span>
+            <span class="out px-1 rounded text-xs font-semibold bg-slate-600">-</span>
+          </div>
           <div class="text-xs text-blue-300">TIRE PRES</div>
           <div class="press text-lg font-bold">0.0</div>
           <div class="assist-status text-xs">TC:OFF</div>
@@ -225,7 +229,11 @@
           <div class="text-xs text-blue-300">BRAKE</div>
           <div class="brake text-lg font-bold">0.0</div>
           <div class="text-xs text-blue-300">TIRE TEMP</div>
-          <div class="temp text-lg font-bold">0.0°C</div>
+          <div class="temp flex justify-center gap-1">
+            <span class="in px-1 rounded text-xs font-semibold bg-slate-600">-</span>
+            <span class="mid px-1 rounded text-xs font-semibold bg-slate-600">-</span>
+            <span class="out px-1 rounded text-xs font-semibold bg-slate-600">-</span>
+          </div>
           <div class="text-xs text-blue-300">TIRE PRES</div>
           <div class="press text-lg font-bold">0.0</div>
           <div class="assist-status text-xs">TC:OFF</div>
@@ -235,7 +243,11 @@
           <div class="text-xs text-blue-300">BRAKE</div>
           <div class="brake text-lg font-bold">0.0</div>
           <div class="text-xs text-blue-300">TIRE TEMP</div>
-          <div class="temp text-lg font-bold">0.0°C</div>
+          <div class="temp flex justify-center gap-1">
+            <span class="in px-1 rounded text-xs font-semibold bg-slate-600">-</span>
+            <span class="mid px-1 rounded text-xs font-semibold bg-slate-600">-</span>
+            <span class="out px-1 rounded text-xs font-semibold bg-slate-600">-</span>
+          </div>
           <div class="text-xs text-blue-300">TIRE PRES</div>
           <div class="press text-lg font-bold">0.0</div>
           <div class="assist-status text-xs">TC:OFF</div>
@@ -245,7 +257,11 @@
           <div class="text-xs text-blue-300">BRAKE</div>
           <div class="brake text-lg font-bold">0.0</div>
           <div class="text-xs text-blue-300">TIRE TEMP</div>
-          <div class="temp text-lg font-bold">0.0°C</div>
+          <div class="temp flex justify-center gap-1">
+            <span class="in px-1 rounded text-xs font-semibold bg-slate-600">-</span>
+            <span class="mid px-1 rounded text-xs font-semibold bg-slate-600">-</span>
+            <span class="out px-1 rounded text-xs font-semibold bg-slate-600">-</span>
+          </div>
           <div class="text-xs text-blue-300">TIRE PRES</div>
           <div class="press text-lg font-bold">0.0</div>
           <div class="assist-status text-xs">TC:OFF</div>
@@ -567,6 +583,15 @@
       if (val >= max) return 'text-status-hot';
       return 'text-status-ideal';
     }
+    function getStatusBgClass(status) {
+      switch ((status||'').toLowerCase()) {
+        case 'cold':    return 'bg-blue-500';
+        case 'ideal':   return 'bg-green-500';
+        case 'warning': return 'bg-yellow-400';
+        case 'hot':     return 'bg-red-500';
+        default:        return 'bg-slate-600';
+      }
+    }
     function getCompoundClass(compound) {
       const s = (compound||'').toLowerCase();
       if (s.includes('soft'))   return 'border-soft';
@@ -604,6 +629,15 @@
                 ? (d.carIdxTireCompounds[d.playerCarIdx] || 'U') : 'U';
             d.tireCompound = [comp,comp,comp,comp];
         }
+        if (!Array.isArray(d.tireStatuses)) {
+            const ts = d.tyreStatus || {};
+            d.tireStatuses = [
+                [ts.lf?.in, ts.lf?.mid, ts.lf?.out],
+                [ts.rf?.in, ts.rf?.mid, ts.rf?.out],
+                [ts.lr?.in, ts.lr?.mid, ts.lr?.out],
+                [ts.rr?.in, ts.rr?.mid, ts.rr?.out]
+            ];
+        }
 
         tireMap.forEach(({id, idx}) => {
             const el = document.getElementById(id);
@@ -623,11 +657,15 @@
                         brakeEl.classList.add(getStatusClass(v, 250, 550, 700));
                     }
                     // Temperatura
-                    if (Array.isArray(d.tireTemps) && tempEl) {
-                        const v = d.tireTemps[idx] ?? 0;
-                        tempEl.textContent = v.toFixed(1) + '°C';
-                        tempEl.classList.remove('text-status-cold','text-status-ideal','text-status-warning','text-status-hot');
-                        tempEl.classList.add(getStatusClass(v, 85, 100, 110));
+                    if (Array.isArray(d.tireStatuses) && tempEl) {
+                        const arr = d.tireStatuses[idx] || [];
+                        const spans = tempEl.querySelectorAll('span');
+                        spans.forEach((sp, i) => {
+                            const st = arr[i] || '';
+                            sp.textContent = st ? st.charAt(0) : '-';
+                            sp.className = sp.className.replace(/bg-[^\s]+/g, '').trim();
+                            sp.classList.add(getStatusBgClass(st));
+                        });
                     }
                     // Pressão
                     if (Array.isArray(d.tirePressures) && pressEl) {


### PR DESCRIPTION
## Summary
- implement `TyreHelpers` with temperature status enum
- enrich `TelemetryModel` with tyre status records
- compute tyre status in `TelemetryCalculationsOverlay`
- send enum as strings via `TelemetryBroadcaster`
- show coloured pills for tyre temps in `overlay-tiresandbrakes`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ed6eecb3883308b997ca1813495d5