### PR TITLE
Fix TyreHelpers reference

### DIFF
--- a/backend/Models/TelemetryModel.cs
+++ b/backend/Models/TelemetryModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using SuperBackendNR85IA.Calculations;
 
 namespace SuperBackendNR85IA.Models
 {


### PR DESCRIPTION
## Summary
- reference TyreHelpers helpers in `TelemetryModel`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eda0ae6d48330b6fe0065f4868503