### PR TITLE
Fix compile warnings and remove unused DefinitionFlags

### DIFF
--- a/backend/Models/TelemetryModel.cs
+++ b/backend/Models/TelemetryModel.cs
@@ -286,7 +286,7 @@ namespace SuperBackendNR85IA.Models
         public int PlayerCarClassID { get; set; }
         public int PlayerCarTeamIncidentCount { get; set; }
         public int PlayerCarMyIncidentCount { get; set; }
-        public string TrackNumTurns { get; set; }
+        public string TrackNumTurns { get; set; } = string.Empty;
         public string TrackDisplayName { get; set; } = string.Empty;
         public string TrackConfigName { get; set; } = string.Empty;
         public float TrackLength { get; set; }

--- a/backend/Services/IRacingTelemetryService.cs
+++ b/backend/Services/IRacingTelemetryService.cs
@@ -22,7 +22,7 @@ namespace SuperBackendNR85IA.Services
         private readonly SessionYamlParser _yamlParser;
 
         private string _lastYaml = string.Empty;
-        private (DriverInfo? Drv, WeekendInfo? Wkd, SessionInfo? Ses, SectorInfo Sec, List<DriverInfo> Drivers) _cachedYamlData;
+        private (DriverInfo? Drv, WeekendInfo? Wkd, SessionInfo? Ses, SectorInfo? Sec, List<DriverInfo> Drivers) _cachedYamlData;
         private int _lastTick = -1;
         private int _lastLap = -1;
         private float _fuelAtLapStart = 0f;
@@ -96,7 +96,7 @@ namespace SuperBackendNR85IA.Services
             {
                 // Habilita todas as variáveis de telemetria, incluindo dados de setup
                 // necessários para pressões frias e desgaste de pneus
-                _sdk.Start(IRSDKSharper.DefinitionFlags.All);
+                _sdk.Start();
                 _log.LogInformation("IRSDKSharper iniciado e aguardando conexão com o iRacing.");
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- remove unsupported `DefinitionFlags` argument when starting the SDK
- mark cached YAML sector info as nullable
- set `TrackNumTurns` default value to avoid nullability warning

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684edaa954008330bf1f820c8ac1562f