### PR TITLE
Fix tire compound field and pressure reading

### DIFF
--- a/backend/Models/TelemetryModel.cs
+++ b/backend/Models/TelemetryModel.cs
@@ -204,6 +204,12 @@ namespace SuperBackendNR85IA.Models
         public float[] CarIdxCarClassEstLapTimes { get; set; } = Array.Empty<float>();
         public string[] CarIdxTireCompounds { get; set; } = Array.Empty<string>();
         public string TireCompound { get; set; } = string.Empty;
+        // Alias enviado ao frontend para compatibilidade
+        public string PlayerCarTireCompound
+        {
+            get => TireCompound;
+            set => TireCompound = value;
+        }
         public string Compound { get => Tyres.Compound; set => Tyres.Compound = value; }
         public int[] CarIdxGear { get => Radar.CarIdxGear; set => Radar.CarIdxGear = value; }
         public float[] CarIdxRPM { get => Radar.CarIdxRPM; set => Radar.CarIdxRPM = value; }

--- a/backend/Services/IRacingTelemetryService.Data.cs
+++ b/backend/Services/IRacingTelemetryService.Data.cs
@@ -401,31 +401,31 @@ namespace SuperBackendNR85IA.Services
             t.Tyres.RrTempCm = GetSdkValue<float>(d, "RRtempCM") ?? 0f;
             t.Tyres.RrTempCr = GetSdkValue<float>(d, "RRtempCR") ?? 0f;
 
+            // Cold pressures from the car setup
             float? lfColdKpa = GetSdkValue<float>(d, "LFcoldPressure");
             float? rfColdKpa = GetSdkValue<float>(d, "RFcoldPressure");
             float? lrColdKpa = GetSdkValue<float>(d, "LRcoldPressure");
             float? rrColdKpa = GetSdkValue<float>(d, "RRcoldPressure");
 
+            // Current tire pressures if available
+            float? lfPress = GetSdkValue<float>(d, "LFpress");
+            float? rfPress = GetSdkValue<float>(d, "RFpress");
+            float? lrPress = GetSdkValue<float>(d, "LRpress");
+            float? rrPress = GetSdkValue<float>(d, "RRpress");
+
             if (lfColdKpa.HasValue)
-            {
                 t.Tyres.LfColdPress = KPaToPsi(lfColdKpa.Value);
-                t.Tyres.LfPress = t.Tyres.LfColdPress;
-            }
             if (rfColdKpa.HasValue)
-            {
                 t.Tyres.RfColdPress = KPaToPsi(rfColdKpa.Value);
-                t.Tyres.RfPress = t.Tyres.RfColdPress;
-            }
             if (lrColdKpa.HasValue)
-            {
                 t.Tyres.LrColdPress = KPaToPsi(lrColdKpa.Value);
-                t.Tyres.LrPress = t.Tyres.LrColdPress;
-            }
             if (rrColdKpa.HasValue)
-            {
                 t.Tyres.RrColdPress = KPaToPsi(rrColdKpa.Value);
-                t.Tyres.RrPress = t.Tyres.RrColdPress;
-            }
+
+            t.Tyres.LfPress = lfPress ?? t.Tyres.LfPress;
+            t.Tyres.RfPress = rfPress ?? t.Tyres.RfPress;
+            t.Tyres.LrPress = lrPress ?? t.Tyres.LrPress;
+            t.Tyres.RrPress = rrPress ?? t.Tyres.RrPress;
             if (!lfColdKpa.HasValue)
             {
                 if (_log.IsEnabled(LogLevel.Debug))


### PR DESCRIPTION
## Summary
- expose `PlayerCarTireCompound` so overlays can read tire compound
- load live tire pressure values from telemetry when available and keep cold pressure separate

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684edf735a9c83309a2acab97080d763