### PR TITLE
Fix build by removing undefined flag

### DIFF
--- a/backend/Services/IRacingTelemetryService.cs
+++ b/backend/Services/IRacingTelemetryService.cs
@@ -96,7 +96,7 @@ namespace SuperBackendNR85IA.Services
             {
                 // Habilita todas as variáveis de telemetria, incluindo dados de setup
                 // necessários para pressões frias/quentes e desgaste de pneus
-                _sdk.Start(DefinitionFlag.All);
+                _sdk.Start();
                 _log.LogInformation("IRSDKSharper iniciado e aguardando conexão com o iRacing.");
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- fix `DefinitionFlag` compile error by removing unused parameter

## Testing
- `N/A`

------
https://chatgpt.com/codex/tasks/task_e_684ee762839c8330a56f9f8710f6c34f