### PR TITLE
Add tyre tread tracking since pit exit

### DIFF
--- a/backend/Models/TelemetryCalculationsOverlay.cs
+++ b/backend/Models/TelemetryCalculationsOverlay.cs
@@ -81,6 +81,15 @@ namespace SuperBackendNR85IA.Calculations
 
             model.Tyres.FrontStagger = (model.RfRideHeight - model.LfRideHeight) * 1000f;
             model.Tyres.RearStagger  = (model.RrRideHeight - model.LrRideHeight) * 1000f;
+
+            if (model.StartTreadFl > 0f)
+                model.TreadWearDiffFl = model.StartTreadFl - model.TreadRemainingFl;
+            if (model.StartTreadFr > 0f)
+                model.TreadWearDiffFr = model.StartTreadFr - model.TreadRemainingFr;
+            if (model.StartTreadRl > 0f)
+                model.TreadWearDiffRl = model.StartTreadRl - model.TreadRemainingRl;
+            if (model.StartTreadRr > 0f)
+                model.TreadWearDiffRr = model.StartTreadRr - model.TreadRemainingRr;
         }
 
         public static void PreencherOverlaySetores(ref TelemetryModel model)

--- a/backend/Models/TelemetryModel.cs
+++ b/backend/Models/TelemetryModel.cs
@@ -153,6 +153,14 @@ namespace SuperBackendNR85IA.Models
         public float TreadRemainingFr { get => Tyres.TreadRemainingFr; set => Tyres.TreadRemainingFr = value; }
         public float TreadRemainingRl { get => Tyres.TreadRemainingRl; set => Tyres.TreadRemainingRl = value; }
         public float TreadRemainingRr { get => Tyres.TreadRemainingRr; set => Tyres.TreadRemainingRr = value; }
+        public float StartTreadFl { get => Tyres.StartTreadFl; set => Tyres.StartTreadFl = value; }
+        public float StartTreadFr { get => Tyres.StartTreadFr; set => Tyres.StartTreadFr = value; }
+        public float StartTreadRl { get => Tyres.StartTreadRl; set => Tyres.StartTreadRl = value; }
+        public float StartTreadRr { get => Tyres.StartTreadRr; set => Tyres.StartTreadRr = value; }
+        public float TreadWearDiffFl { get => Tyres.TreadWearDiffFl; set => Tyres.TreadWearDiffFl = value; }
+        public float TreadWearDiffFr { get => Tyres.TreadWearDiffFr; set => Tyres.TreadWearDiffFr = value; }
+        public float TreadWearDiffRl { get => Tyres.TreadWearDiffRl; set => Tyres.TreadWearDiffRl = value; }
+        public float TreadWearDiffRr { get => Tyres.TreadWearDiffRr; set => Tyres.TreadWearDiffRr = value; }
         public float? TreadLF { get => Tyres.TreadLF; set => Tyres.TreadLF = value; }
         public float? TreadRF { get => Tyres.TreadRF; set => Tyres.TreadRF = value; }
         public float? TreadLR { get => Tyres.TreadLR; set => Tyres.TreadLR = value; }

--- a/backend/Models/TyreData.cs
+++ b/backend/Models/TyreData.cs
@@ -101,6 +101,16 @@ namespace SuperBackendNR85IA.Models
         public float TreadRemainingRl { get; set; }
         public float TreadRemainingRr { get; set; }
 
+        public float StartTreadFl { get; set; }
+        public float StartTreadFr { get; set; }
+        public float StartTreadRl { get; set; }
+        public float StartTreadRr { get; set; }
+
+        public float TreadWearDiffFl { get; set; }
+        public float TreadWearDiffFr { get; set; }
+        public float TreadWearDiffRl { get; set; }
+        public float TreadWearDiffRr { get; set; }
+
         public float? TreadLF { get; set; }
         public float? TreadRF { get; set; }
         public float? TreadLR { get; set; }

--- a/backend/Services/IRacingTelemetryService.cs
+++ b/backend/Services/IRacingTelemetryService.cs
@@ -69,6 +69,10 @@ namespace SuperBackendNR85IA.Services
         private float _rrColdTempCl;
         private float _rrColdTempCm;
         private float _rrColdTempCr;
+        private float _lfStartTread;
+        private float _rfStartTread;
+        private float _lrStartTread;
+        private float _rrStartTread;
         private bool _loggedAvailableVars = false;
         private readonly HashSet<string> _missingVarWarned = new();
 
@@ -230,10 +234,17 @@ namespace SuperBackendNR85IA.Services
                 _rrColdTempCl = t.RrTempCl;
                 _rrColdTempCm = t.RrTempCm;
                 _rrColdTempCr = t.RrTempCr;
+
+                _lfStartTread = t.TreadRemainingFl;
+                _rfStartTread = t.TreadRemainingFr;
+                _lrStartTread = t.TreadRemainingRl;
+                _rrStartTread = t.TreadRemainingRr;
+
                 _log.LogInformation(
                     $"Pit exit - cold pressures LF:{_lfColdPress} RF:{_rfColdPress} LR:{_lrColdPress} RR:{_rrColdPress}, " +
                     $"temps LF:{_lfColdTempCl}/{_lfColdTempCm}/{_lfColdTempCr} RF:{_rfColdTempCl}/{_rfColdTempCm}/{_rfColdTempCr} " +
-                    $"LR:{_lrColdTempCl}/{_lrColdTempCm}/{_lrColdTempCr} RR:{_rrColdTempCl}/{_rrColdTempCm}/{_rrColdTempCr}");
+                    $"LR:{_lrColdTempCl}/{_lrColdTempCm}/{_lrColdTempCr} RR:{_rrColdTempCl}/{_rrColdTempCm}/{_rrColdTempCr}, " +
+                    $"tread FL:{_lfStartTread} FR:{_rfStartTread} RL:{_lrStartTread} RR:{_rrStartTread}");
             }
 
             // Valores iniciais caso o serviço seja iniciado no meio da pista
@@ -260,6 +271,11 @@ namespace SuperBackendNR85IA.Services
             if (_rfLastHotPress == 0f && t.RfPress > 0f) { _rfLastHotPress = t.RfPress; initialUpdate = true; }
             if (_lrLastHotPress == 0f && t.LrPress > 0f) { _lrLastHotPress = t.LrPress; initialUpdate = true; }
             if (_rrLastHotPress == 0f && t.RrPress > 0f) { _rrLastHotPress = t.RrPress; initialUpdate = true; }
+
+            if (_lfStartTread == 0f && t.TreadRemainingFl > 0f) { _lfStartTread = t.TreadRemainingFl; initialUpdate = true; }
+            if (_rfStartTread == 0f && t.TreadRemainingFr > 0f) { _rfStartTread = t.TreadRemainingFr; initialUpdate = true; }
+            if (_lrStartTread == 0f && t.TreadRemainingRl > 0f) { _lrStartTread = t.TreadRemainingRl; initialUpdate = true; }
+            if (_rrStartTread == 0f && t.TreadRemainingRr > 0f) { _rrStartTread = t.TreadRemainingRr; initialUpdate = true; }
 
             if (_lfLastTempCl == 0f && t.LfTempCl > 0f) { _lfLastTempCl = t.LfTempCl; initialUpdate = true; }
             if (_lfLastTempCm == 0f && t.LfTempCm > 0f) { _lfLastTempCm = t.LfTempCm; initialUpdate = true; }
@@ -304,6 +320,10 @@ namespace SuperBackendNR85IA.Services
             t.RfLastHotPress = _rfLastHotPress;
             t.LrLastHotPress = _lrLastHotPress;
             t.RrLastHotPress = _rrLastHotPress;
+            t.LfStartTread = _lfStartTread;
+            t.RfStartTread = _rfStartTread;
+            t.LrStartTread = _lrStartTread;
+            t.RrStartTread = _rrStartTread;
 
             // Preserve real-time hot pressures read from the SDK. Only fall
             // back to the last recorded values if no current data is


### PR DESCRIPTION
## Summary
- store tread values on pit exit and expose them via `TelemetryModel`
- compute tread wear delta in overlay calculations so overlays can show tire wear since leaving the pits

## Testing
- `dotnet build backend/SuperBackendNR85IA.csproj -nologo` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f0a265a18833097b84c27eea19328