### PR TITLE
Add tire data diagnostic overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Each overlay corresponds to an HTML file in `telemetry-frontend/public/overlays`
 - **Base** – basic classification template overlay.
 - **Radar** – circular radar indicating nearby cars with alerts.
 - **Teste Final** – diagnostic overlay combining various widgets.
+- **Tires Raw** – displays every tire-related value received from iRacing.
 
 More details sobre os dados de pneus necessários podem ser encontrados em
 `docs/overlay-tires-checklist.md`.

--- a/telemetry-frontend/public/overlays/overlay-tiresraw.html
+++ b/telemetry-frontend/public/overlays/overlay-tiresraw.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tires Raw Data</title>
+  <style>
+    html,body { margin:0; padding:0; height:100%; background:#111; color:#e2e8f0; font-family: monospace; font-size:12px; }
+    pre { margin:0; padding:0.5rem; white-space: pre-wrap; word-break: break-all; overflow:auto; height:100%; }
+  </style>
+</head>
+<body>
+<pre id="output">Conectando...</pre>
+<script type="module">
+import { initOverlayWebSocket } from '../overlay-common.js';
+
+const output = document.getElementById('output');
+
+function filterTireData(src) {
+  const prefixes = ['lf', 'rf', 'lr', 'rr'];
+  const extras = ['tireCompound', 'compound', 'frontStagger', 'rearStagger'];
+  const result = {};
+  for (const [key, value] of Object.entries(src)) {
+    const lower = key.toLowerCase();
+    if (prefixes.some(p => lower.startsWith(p)) || extras.includes(key)) {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+function handleData(data) {
+  const flat = { ...data, ...(data.tyres || data.tires || {}) };
+  output.textContent = JSON.stringify(filterTireData(flat), null, 2);
+}
+
+initOverlayWebSocket(handleData);
+</script>
+</body>
+</html>

--- a/telemetry-frontend/src/overlayList.js
+++ b/telemetry-frontend/src/overlayList.js
@@ -11,5 +11,6 @@ export default [
   { name: 'Tire Wear', file: 'overlay-tirewear.html' },
   { name: 'Base', file: 'overlaybase.html' },
   { name: 'Teste Final', file: 'overlay-testefinal.html' },
-  { name: 'Diagnóstico Raw', file: 'overlay-diagnostico-raw.html' }
+  { name: 'Diagnóstico Raw', file: 'overlay-diagnostico-raw.html' },
+  { name: 'Tires Raw', file: 'overlay-tiresraw.html' }
 ];


### PR DESCRIPTION
## Summary
- add a new `Tires Raw` overlay to visualize every tire-related field from the backend
- expose the new overlay in the electron menu
- document the new overlay in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f174a5d288330aabdd22ef47d4e6b