### PR TITLE
Fix initial hot pressure capture

### DIFF
--- a/backend/Models/TyreData.cs
+++ b/backend/Models/TyreData.cs
@@ -121,5 +121,33 @@ namespace SuperBackendNR85IA.Models
         public float RfRideHeight { get; set; }
         public float LrRideHeight { get; set; }
         public float RrRideHeight { get; set; }
+
+        private static float PsiToKpa(float psi) => psi <= 0f ? 0f : psi / 0.1450377f;
+
+        // --- Helper properties for kPa values ---
+        public float LfPressKpa => PsiToKpa(LfPress);
+        public float RfPressKpa => PsiToKpa(RfPress);
+        public float LrPressKpa => PsiToKpa(LrPress);
+        public float RrPressKpa => PsiToKpa(RrPress);
+
+        public float LfColdPressKpa => PsiToKpa(LfColdPress);
+        public float RfColdPressKpa => PsiToKpa(RfColdPress);
+        public float LrColdPressKpa => PsiToKpa(LrColdPress);
+        public float RrColdPressKpa => PsiToKpa(RrColdPress);
+
+        public float LfHotPressureKpa => PsiToKpa(LfHotPressure);
+        public float RfHotPressureKpa => PsiToKpa(RfHotPressure);
+        public float LrHotPressureKpa => PsiToKpa(LrHotPressure);
+        public float RrHotPressureKpa => PsiToKpa(RrHotPressure);
+
+        public float LfSetupPressureKpa => PsiToKpa(LfSetupPressure);
+        public float RfSetupPressureKpa => PsiToKpa(RfSetupPressure);
+        public float LrSetupPressureKpa => PsiToKpa(LrSetupPressure);
+        public float RrSetupPressureKpa => PsiToKpa(RrSetupPressure);
+
+        public float LfLastHotPressKpa => PsiToKpa(LfLastHotPress);
+        public float RfLastHotPressKpa => PsiToKpa(RfLastHotPress);
+        public float LrLastHotPressKpa => PsiToKpa(LrLastHotPress);
+        public float RrLastHotPressKpa => PsiToKpa(RrLastHotPress);
     }
 }

--- a/backend/Services/IRacingTelemetryService.cs
+++ b/backend/Services/IRacingTelemetryService.cs
@@ -36,6 +36,7 @@ namespace SuperBackendNR85IA.Services
         private string _trackName = string.Empty;
         private bool _awaitingStoredData = false;
         private bool _wasOnPitRoad = false;
+        private bool _initialized = false;
         private int _lastPitCount = -1;
         private float _lfLastHotPress;
         private float _rfLastHotPress;
@@ -189,7 +190,15 @@ namespace SuperBackendNR85IA.Services
 
         private void UpdateLastHotPress(TelemetryModel t)
         {
-            if (t.OnPitRoad && !_wasOnPitRoad)
+            if (!_initialized)
+            {
+                // Ignore the first update to avoid recording pit entry
+                // values when the service starts while the car is stopped
+                // in the pit lane.
+                _wasOnPitRoad = t.OnPitRoad;
+                _initialized = true;
+            }
+            else if (t.OnPitRoad && !_wasOnPitRoad)
             {
                 // Entrando nos boxes: registra pressões e temperaturas quentes
                 _lfLastHotPress = t.LfPress;


### PR DESCRIPTION
## Summary
- avoid recording hot pressures when starting in the pits
- add initialization flag in telemetry service
- expose tire pressures in kPa as well as psi for the frontend

## Testing
- `npm test --silent --prefix telemetry-frontend`


------
https://chatgpt.com/codex/tasks/task_e_684f1b5e2a5c8330b7348339d6623fa6