### PR TITLE
Add tread remaining fields

### DIFF
--- a/backend/Models/TelemetryCalculationsOverlay.cs
+++ b/backend/Models/TelemetryCalculationsOverlay.cs
@@ -90,6 +90,12 @@ namespace SuperBackendNR85IA.Calculations
                 model.TreadWearDiffRl = model.StartTreadRl - model.TreadRemainingRl;
             if (model.StartTreadRr > 0f)
                 model.TreadWearDiffRr = model.StartTreadRr - model.TreadRemainingRr;
+
+            // Ensure per-wheel tread values are available for the UI
+            model.Tyres.TreadLF ??= model.TreadRemainingFl;
+            model.Tyres.TreadRF ??= model.TreadRemainingFr;
+            model.Tyres.TreadLR ??= model.TreadRemainingRl;
+            model.Tyres.TreadRR ??= model.TreadRemainingRr;
         }
 
         public static void PreencherOverlaySetores(ref TelemetryModel model)

--- a/ws/messages/overlay_message.json
+++ b/ws/messages/overlay_message.json
@@ -65,6 +65,10 @@
   "rfTreadRemainingParts": [0.94, 0.93, 0.94],
   "lrTreadRemainingParts": [0.96, 0.95, 0.96],
   "rrTreadRemainingParts": [0.96, 0.95, 0.96],
+  "treadLF": 0.94,
+  "treadRF": 0.93,
+  "treadLR": 0.95,
+  "treadRR": 0.95,
   "carIdxPosition": [
     1,
     2


### PR DESCRIPTION
## Summary
- update overlay calculations to ensure per-wheel tread values are always present
- extend example overlay message with tread metrics

## Testing
- `npm test --prefix telemetry-frontend`

------
https://chatgpt.com/codex/tasks/task_e_684f4919a0e4833088b2e6f58e897b5a