### PR TITLE
Add full data overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Each overlay corresponds to an HTML file in `telemetry-frontend/public/overlays`
 - **Radar** – circular radar indicating nearby cars with alerts.
 - **Teste Final** – diagnostic overlay combining various widgets.
 - **Tires Raw** – displays every tire-related value received from iRacing.
+- **Dados Completos** – shows all backend data, including the raw YAML and parsed fields.
 
 More details sobre os dados de pneus necessários podem ser encontrados em
 `docs/overlay-tires-checklist.md`.

--- a/telemetry-frontend/public/overlays/overlay-dadoscompletos.html
+++ b/telemetry-frontend/public/overlays/overlay-dadoscompletos.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dados Completos</title>
+  <style>
+    html,body { margin:0; padding:0; height:100%; background:#111; color:#e2e8f0; font-family: monospace; font-size:12px; }
+    .container { display:flex; height:100%; }
+    pre { flex:1; margin:0; padding:0.5rem; white-space: pre-wrap; word-break: break-all; overflow:auto; }
+    pre:first-child { border-right:1px solid #333; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <pre id="yaml">Conectando...</pre>
+    <pre id="json">Conectando...</pre>
+  </div>
+  <script type="module">
+    import { initOverlayWebSocket } from '../overlay-common.js';
+    const preYaml = document.getElementById('yaml');
+    const preJson = document.getElementById('json');
+    function handleData(data) {
+      preJson.textContent = JSON.stringify(data, null, 2);
+      preYaml.textContent = data.sessionInfoYaml || '';
+    }
+    initOverlayWebSocket(handleData);
+  </script>
+</body>
+</html>

--- a/telemetry-frontend/src/overlayList.js
+++ b/telemetry-frontend/src/overlayList.js
@@ -12,5 +12,6 @@ export default [
   { name: 'Base', file: 'overlaybase.html' },
   { name: 'Teste Final', file: 'overlay-testefinal.html' },
   { name: 'Diagnóstico Raw', file: 'overlay-diagnostico-raw.html' },
-  { name: 'Tires Raw', file: 'overlay-tiresraw.html' }
+  { name: 'Tires Raw', file: 'overlay-tiresraw.html' },
+  { name: 'Dados Completos', file: 'overlay-dadoscompletos.html' }
 ];


### PR DESCRIPTION
## Summary
- add an overlay displaying raw YAML and JSON data
- register the new overlay in the menu
- document the overlay in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f53e6f30c8330b8a17862242dea24