### PR TITLE
Fix WebSocket binding issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project contains a .NET backend that streams telemetry data through WebSock
  dotnet run --project backend/SuperBackendNR85IA.csproj
 ```
 
-This starts the WebSocket server on `http://localhost:5221`. Overlays connect to the `/ws` endpoint on that port. You can provide a custom WebSocket URL to the overlays by setting the environment variable `OVERLAY_WS_URL` before launching the Electron app or by defining `window.OVERLAY_WS_URL` in a browser.
+This starts the WebSocket server on `http://0.0.0.0:5221` (or the value of the `BACKEND_BIND_URL` environment variable). Overlays connect to the `/ws` endpoint on that port. You can provide a custom WebSocket URL to the overlays by setting the environment variable `OVERLAY_WS_URL` before launching the Electron app or by defining `window.OVERLAY_WS_URL` in a browser. If you need to bind to a different address/port, set `BACKEND_BIND_URL` before running the backend.
 
 ## Running the Electron frontend
 

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -8,7 +8,10 @@ using SuperBackendNR85IA.Services;
 var builder = WebApplication.CreateBuilder(args);
 
 // Porta única para HTTP + WebSocket, igual às overlays
-builder.WebHost.UseUrls("http://localhost:5221");
+// Permite definir a URL de binding via variável de ambiente BACKEND_BIND_URL
+var bindUrl = Environment.GetEnvironmentVariable("BACKEND_BIND_URL")
+               ?? "http://0.0.0.0:5221"; // aceita conexões de outras máquinas
+builder.WebHost.UseUrls(bindUrl);
 
 // DI ------------------------------------------------------------------------
 builder.Services.AddSingleton<TelemetryBroadcaster>();


### PR DESCRIPTION
## Summary
- allow binding to an arbitrary host by checking `BACKEND_BIND_URL`
- document new environment variable in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f57fa91b08330a88d73918bdc252a