### PR TITLE
Add CarStatusPayload support

### DIFF
--- a/backend/Models/CarStatusPayload.cs
+++ b/backend/Models/CarStatusPayload.cs
@@ -1,0 +1,57 @@
+using System.Text.Json.Serialization;
+
+namespace SuperBackendNR85IA.Models
+{
+    public class CarStatusPayload
+    {
+        // Dados básicos de movimento
+        [JsonPropertyName("speed")] public float Speed { get; set; }
+        [JsonPropertyName("rpm")] public float Rpm { get; set; }
+        [JsonPropertyName("gear")] public int Gear { get; set; }
+
+        // Pedais
+        [JsonPropertyName("throttle")] public float Throttle { get; set; }
+        [JsonPropertyName("throttleRaw")] public float ThrottleRaw { get; set; }
+        [JsonPropertyName("brake")] public float Brake { get; set; }
+        [JsonPropertyName("brakeRaw")] public float BrakeRaw { get; set; }
+        [JsonPropertyName("clutch")] public float Clutch { get; set; }
+        [JsonPropertyName("handBrake")] public float HandBrake { get; set; }
+        [JsonPropertyName("handBrakeRaw")] public float HandBrakeRaw { get; set; }
+
+        // Direção e FFB
+        [JsonPropertyName("steeringWheelAngle")] public float SteeringWheelAngle { get; set; }
+        [JsonPropertyName("steeringWheelAngleMax")] public float SteeringWheelAngleMax { get; set; }
+        [JsonPropertyName("steeringWheelTorque")] public float SteeringWheelTorque { get; set; }
+        [JsonPropertyName("steeringWheelPeakForceNm")] public float SteeringWheelPeakForceNm { get; set; }
+        [JsonPropertyName("steeringWheelPctDamper")] public float SteeringWheelPctDamper { get; set; }
+        [JsonPropertyName("steeringWheelPctTorque")] public float SteeringWheelPctTorque { get; set; }
+
+        // ABS/Traction/Assistências
+        [JsonPropertyName("brakeABSactive")] public bool BrakeABSactive { get; set; }
+        [JsonPropertyName("brakeABSCutPct")] public float BrakeABSCutPct { get; set; }
+
+        // Combustível
+        [JsonPropertyName("fuelLevel")] public float FuelLevel { get; set; }
+        [JsonPropertyName("fuelLevelPct")] public float FuelLevelPct { get; set; }
+        [JsonPropertyName("fuelUsePerLap")] public float FuelUsePerLap { get; set; }
+        [JsonPropertyName("fuelUsePerLapCalc")] public float FuelUsePerLapCalc { get; set; }
+        [JsonPropertyName("consumoMedio")] public float ConsumoMedio { get; set; }
+        [JsonPropertyName("voltasRestantesMedio")] public float VoltasRestantesMedio { get; set; }
+
+        // Temperaturas e Pressões do carro
+        [JsonPropertyName("waterTemp")] public float WaterTemp { get; set; }
+        [JsonPropertyName("oilTemp")] public float OilTemp { get; set; }
+        [JsonPropertyName("oilPress")] public float OilPress { get; set; }
+        [JsonPropertyName("fuelPress")] public float FuelPress { get; set; }
+        [JsonPropertyName("manifoldPress")] public float ManifoldPress { get; set; }
+
+        // Status e alertas
+        [JsonPropertyName("engineWarnings")] public int EngineWarnings { get; set; }
+        [JsonPropertyName("onPitRoad")] public bool OnPitRoad { get; set; }
+
+        // Extras úteis para overlays de inputs
+        [JsonPropertyName("yawRate")] public float YawRate { get; set; }
+        [JsonPropertyName("pitchRate")] public float PitchRate { get; set; }
+        [JsonPropertyName("rollRate")] public float RollRate { get; set; }
+    }
+}

--- a/backend/Models/FrontendDataPayload.cs
+++ b/backend/Models/FrontendDataPayload.cs
@@ -13,6 +13,7 @@ namespace SuperBackendNR85IA.Models
         [JsonPropertyName("results")] public List<ResultPayload>? Results { get; set; }
         [JsonPropertyName("proximityCars")] public List<ProximityCar>? ProximityCars { get; set; }
         [JsonPropertyName("tyres")] public TyrePayload? Tyres { get; set; }
+        [JsonPropertyName("carStatus")] public CarStatusPayload? CarStatus { get; set; }
     }
 
 

--- a/backend/Services/IRacingTelemetryService.cs
+++ b/backend/Services/IRacingTelemetryService.cs
@@ -514,6 +514,43 @@ namespace SuperBackendNR85IA.Services
                     TreadLR = t.Tyres.TreadLR,
                     TreadRR = t.Tyres.TreadRR,
                     Compound = t.Tyres.Compound
+                },
+                CarStatus = new CarStatusPayload
+                {
+                    Speed = t.Vehicle.Speed,
+                    Rpm = t.Vehicle.Rpm,
+                    Gear = t.Vehicle.Gear,
+                    Throttle = t.Vehicle.Throttle,
+                    ThrottleRaw = t.Vehicle.ThrottleRaw,
+                    Brake = t.Vehicle.Brake,
+                    BrakeRaw = t.Vehicle.BrakeRaw,
+                    Clutch = t.Vehicle.Clutch,
+                    HandBrake = t.Vehicle.HandBrake,
+                    HandBrakeRaw = t.Vehicle.HandBrakeRaw,
+                    SteeringWheelAngle = t.Vehicle.SteeringWheelAngle,
+                    SteeringWheelAngleMax = t.Vehicle.SteeringWheelAngleMax,
+                    SteeringWheelTorque = t.Vehicle.SteeringWheelTorque,
+                    SteeringWheelPeakForceNm = t.Vehicle.SteeringWheelPeakForceNm,
+                    SteeringWheelPctDamper = t.Vehicle.SteeringWheelPctDamper,
+                    SteeringWheelPctTorque = t.Vehicle.SteeringWheelPctTorque,
+                    BrakeABSactive = t.Vehicle.BrakeABSactive,
+                    BrakeABSCutPct = t.Vehicle.BrakeABSCutPct,
+                    FuelLevel = t.Vehicle.FuelLevel,
+                    FuelLevelPct = t.Vehicle.FuelLevelPct,
+                    FuelUsePerLap = t.FuelUsePerLap,
+                    FuelUsePerLapCalc = t.FuelUsePerLapCalc,
+                    ConsumoMedio = t.ConsumoMedio,
+                    VoltasRestantesMedio = t.VoltasRestantesMedio,
+                    WaterTemp = t.Vehicle.WaterTemp,
+                    OilTemp = t.Vehicle.OilTemp,
+                    OilPress = t.Vehicle.OilPress,
+                    FuelPress = t.Vehicle.FuelPress,
+                    ManifoldPress = t.Vehicle.ManifoldPress,
+                    EngineWarnings = t.Vehicle.EngineWarnings,
+                    OnPitRoad = t.Vehicle.OnPitRoad,
+                    YawRate = t.Vehicle.YawRate,
+                    PitchRate = t.Vehicle.PitchRate,
+                    RollRate = t.Vehicle.RollRate
                 }
             };
         }


### PR DESCRIPTION
## Summary
- add `CarStatusPayload` model for driver inputs
- expose new `carStatus` field in `FrontendDataPayload`
- populate the field in `BuildFrontendPayload`

## Testing
- `dotnet build backend/SuperBackendNR85IA.csproj -c Release` *(fails: dotnet not installed)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f846f91248330b78f60ebe8f2f273