### PR TITLE
Add radar relative payload

### DIFF
--- a/backend/Models/FrontendDataPayload.cs
+++ b/backend/Models/FrontendDataPayload.cs
@@ -12,6 +12,7 @@ namespace SuperBackendNR85IA.Models
         [JsonPropertyName("weekendInfo")] public WeekendInfoPayload? WeekendInfo { get; set; }
         [JsonPropertyName("results")] public List<ResultPayload>? Results { get; set; }
         [JsonPropertyName("proximityCars")] public List<ProximityCar>? ProximityCars { get; set; }
+        [JsonPropertyName("radarRelative")] public RadarRelativePayload? RadarRelative { get; set; }
         [JsonPropertyName("tyres")] public TyrePayload? Tyres { get; set; }
     }
 

--- a/backend/Models/RadarRelativePayload.cs
+++ b/backend/Models/RadarRelativePayload.cs
@@ -1,0 +1,32 @@
+using System.Text.Json.Serialization;
+
+namespace SuperBackendNR85IA.Models
+{
+    public class RadarCarPayload
+    {
+        [JsonPropertyName("carIdx")] public int CarIdx { get; set; }
+        [JsonPropertyName("posX")] public float PosX { get; set; }
+        [JsonPropertyName("posY")] public float PosY { get; set; }
+        [JsonPropertyName("gap")] public float Gap { get; set; }
+        [JsonPropertyName("deltaLap")] public int DeltaLap { get; set; }
+        [JsonPropertyName("onPitRoad")] public bool OnPitRoad { get; set; }
+        [JsonPropertyName("trackSurface")] public int TrackSurface { get; set; }
+        [JsonPropertyName("carClassId")] public int CarClassId { get; set; }
+        [JsonPropertyName("carClassShortName")] public string CarClassShortName { get; set; } = string.Empty;
+        [JsonPropertyName("userName")] public string UserName { get; set; } = string.Empty;
+        [JsonPropertyName("carNumber")] public string CarNumber { get; set; } = string.Empty;
+        [JsonPropertyName("license")] public string License { get; set; } = string.Empty;
+        [JsonPropertyName("iRating")] public int IRating { get; set; }
+        [JsonPropertyName("tireCompound")] public string TireCompound { get; set; } = string.Empty;
+        [JsonPropertyName("isFastestLap")] public bool IsFastestLap { get; set; }
+        [JsonPropertyName("isSameClass")] public bool IsSameClass { get; set; }
+        [JsonPropertyName("isPlayer")] public bool IsPlayer { get; set; }
+    }
+
+    public class RadarRelativePayload
+    {
+        [JsonPropertyName("playerCarIdx")] public int PlayerCarIdx { get; set; }
+        [JsonPropertyName("trackLength")] public float TrackLength { get; set; }
+        [JsonPropertyName("radarCars")] public RadarCarPayload[] RadarCars { get; set; } = System.Array.Empty<RadarCarPayload>();
+    }
+}

--- a/backend/Services/IRacingTelemetryService.cs
+++ b/backend/Services/IRacingTelemetryService.cs
@@ -463,6 +463,52 @@ namespace SuperBackendNR85IA.Services
                 NewIRating = r.NewIRating
             }).ToList();
 
+            RadarRelativePayload? radarRelative = null;
+            if (t.CarIdxPosition.Length > 0)
+            {
+                int count = t.CarIdxPosition.Length;
+                radarRelative = new RadarRelativePayload
+                {
+                    PlayerCarIdx = t.PlayerCarIdx,
+                    TrackLength = t.TrackLength,
+                    RadarCars = Enumerable.Range(0, count)
+                        .Select(idx =>
+                        {
+                            float posX = 0f, posY = 0f;
+                            if (idx < t.CarIdxLapDistPct.Length)
+                            {
+                                double ang = t.CarIdxLapDistPct[idx] * 2.0 * Math.PI;
+                                posX = (float)Math.Cos(ang);
+                                posY = (float)Math.Sin(ang);
+                            }
+
+                            bool onPit = idx < t.CarIdxOnPitRoad.Length && t.CarIdxOnPitRoad[idx];
+
+                            return new RadarCarPayload
+                            {
+                                CarIdx = idx,
+                                PosX = posX,
+                                PosY = posY,
+                                Gap = idx < t.CarIdxF2Time.Length ? t.CarIdxF2Time[idx] : 0f,
+                                DeltaLap = (idx < t.CarIdxLap.Length ? t.CarIdxLap[idx] : 0) - t.Lap,
+                                OnPitRoad = onPit,
+                                TrackSurface = idx < t.CarIdxTrackSurface.Length ? t.CarIdxTrackSurface[idx] : 0,
+                                CarClassId = idx < t.CarIdxCarClassIds.Length ? t.CarIdxCarClassIds[idx] : 0,
+                                CarClassShortName = idx < t.CarIdxCarClassShortNames.Length ? t.CarIdxCarClassShortNames[idx] : string.Empty,
+                                UserName = idx < t.CarIdxUserNames.Length ? t.CarIdxUserNames[idx] : string.Empty,
+                                CarNumber = idx < t.CarIdxCarNumbers.Length ? t.CarIdxCarNumbers[idx] : string.Empty,
+                                License = idx < t.CarIdxLicStrings.Length ? t.CarIdxLicStrings[idx] : string.Empty,
+                                IRating = idx < t.CarIdxIRatings.Length ? t.CarIdxIRatings[idx] : 0,
+                                TireCompound = idx < t.CarIdxTireCompounds.Length ? t.CarIdxTireCompounds[idx] : string.Empty,
+                                IsFastestLap = idx < t.CarIdxBestLapTime.Length && Math.Abs(t.CarIdxBestLapTime[idx] - t.LapBestLapTime) < 1e-4f,
+                                IsSameClass = idx < t.CarIdxCarClassIds.Length && t.CarIdxCarClassIds[idx] == t.PlayerCarClassID,
+                                IsPlayer = idx == t.PlayerCarIdx
+                            };
+                        })
+                        .ToArray()
+                };
+            }
+
             return new FrontendDataPayload
             {
                 Telemetry = t,
@@ -471,6 +517,7 @@ namespace SuperBackendNR85IA.Services
                 WeekendInfo = weekendInfo,
                 Results = results ?? new List<ResultPayload>(),
                 ProximityCars = null,
+                RadarRelative = radarRelative,
                 Tyres = new TyrePayload
                 {
                     LfPress = t.Tyres.LfPress,


### PR DESCRIPTION
## Summary
- add `RadarRelativePayload` model to describe relative car radar data
- expose `radarRelative` field in `FrontendDataPayload`
- build radar relative info in `IRacingTelemetryService`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f84f0b4f883308df5c7588ec3db5d