### PR TITLE
Restore session info YAML in WS payload

### DIFF
--- a/backend/Models/FrontendDataPayload.cs
+++ b/backend/Models/FrontendDataPayload.cs
@@ -16,6 +16,7 @@ namespace SuperBackendNR85IA.Models
         [JsonPropertyName("tyres")] public TyrePayload? Tyres { get; set; }
         [JsonPropertyName("sectorsDelta")] public SectorsDeltaPayload? SectorsDelta { get; set; }
         [JsonPropertyName("weather")] public WeatherPayload? Weather { get; set; }
+        [JsonPropertyName("sessionInfoYaml")] public string SessionInfoYaml { get; set; } = string.Empty;
     }
 
 

--- a/backend/Services/IRacingTelemetryService.cs
+++ b/backend/Services/IRacingTelemetryService.cs
@@ -593,7 +593,8 @@ namespace SuperBackendNR85IA.Services
                     WeatherDeclaredWet = t.WeatherDeclaredWet,
                     TrackGripStatus = t.TrackGripStatus,
                     Forecast = t.ForecastType
-                }
+                },
+                SessionInfoYaml = t.SessionInfoYaml
             };
         }
 


### PR DESCRIPTION
## Summary
- include the `sessionInfoYaml` field in `FrontendDataPayload`
- populate `sessionInfoYaml` in `IRacingTelemetryService`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f87a359688330aa61b47413c686ff