### PR TITLE
Update inputs overlay for new payload structure

### DIFF
--- a/telemetry-frontend/public/overlays/overlay-inputs.html
+++ b/telemetry-frontend/public/overlays/overlay-inputs.html
@@ -666,12 +666,15 @@
 
         function updateOverlayData(d) {
             if (!d) return;
-            throttle = Math.min(1, Math.max(0, parseFloat(d.throttle ?? 0)));
-            brake    = Math.min(1, Math.max(0, parseFloat(d.brake    ?? 0)));
-            steer    = Math.min(1, Math.max(-1, parseFloat(d.steeringWheelAngle ?? 0)));
-            
+            const src = d.telemetry || d;
+            const model = { ...src, ...(src.vehicle || {}), ...(src.session || {}), ...(src.tyres || {}), ...(src.damage || {}) };
+
+            throttle = Math.min(1, Math.max(0, parseFloat(model.throttle ?? 0)));
+            brake    = Math.min(1, Math.max(0, parseFloat(model.brake    ?? 0)));
+            steer    = Math.min(1, Math.max(-1, parseFloat(model.steeringWheelAngle ?? 0)));
+
             let newGearDisplay = currentGear;
-            const gearRaw = d.gear;
+            const gearRaw = model.gear;
             if (typeof gearRaw !== 'undefined') {
                 const rawGear = parseInt(gearRaw, 10);
                 if (!isNaN(rawGear)) {
@@ -723,9 +726,7 @@
             const { initOverlayWebSocket, enableBrowserEditMode } = await import('../overlay-common.js');
             isElectron = enableBrowserEditMode('wrapper', overlayHeader);
             initOverlayWebSocket(data => {
-                if (typeof data.throttle !== 'undefined') {
-                    updateOverlayData(data);
-                }
+                updateOverlayData(data);
             });
         });
 

--- a/telemetry-frontend/public/overlays/overlay-sessao.html
+++ b/telemetry-frontend/public/overlays/overlay-sessao.html
@@ -406,7 +406,10 @@
 
         </div> </div> </div> <script>
     const q = s => document.querySelector(s);
-    const wsUrl = (location.protocol === 'https:' ? 'wss' : 'ws') + '://localhost:5221/ws';
+    // Use custom WS URL if provided, otherwise match the page's host
+    const wsUrl = window.OVERLAY_WS_URL ||
+        ((location.protocol === 'https:' ? 'wss' : 'ws') + '://' +
+         (location.hostname || 'localhost') + ':5221/ws');
     let ws;
     let lastFullData = null;
     const OVERLAY_NAME = 'session-overlay-detailed-v2-com-setores'; // Nome único atualizado


### PR DESCRIPTION
## Summary
- flatten nested telemetry fields in the inputs overlay
- always process incoming WS messages in the inputs overlay

## Testing
- `npm --prefix telemetry-frontend test`


------
https://chatgpt.com/codex/tasks/task_e_684f8967c5048330b08b90e59c305c06