### PR TITLE
Fix missing fields for telemetry parsing

### DIFF
--- a/backend/Models/DriverInfo.cs
+++ b/backend/Models/DriverInfo.cs
@@ -18,5 +18,6 @@ namespace SuperBackendNR85IA.Models
         public float  CarClassRelSpeed  { get; set; }
         public float  CarClassEstLapTime { get; set; }
         public string TireCompound { get; set; } = string.Empty;
+        public int    TeamIncidentCount { get; set; }
     }
 }

--- a/backend/Models/ResultPosition.cs
+++ b/backend/Models/ResultPosition.cs
@@ -6,8 +6,11 @@ namespace SuperBackendNR85IA.Models
         public int CarIdx { get; set; }
         public float FastestTime { get; set; }
         public float LastTime { get; set; }
+        public float Time { get; set; }
+        public float Interval { get; set; }
         public bool OnPitRoad { get; set; }
         public bool InGarage { get; set; }
         public int PitStopCount { get; set; }
+        public int NewIRating { get; set; }
     }
 }

--- a/backend/Services/SessionYamlParser.cs
+++ b/backend/Services/SessionYamlParser.cs
@@ -67,7 +67,8 @@ namespace SuperBackendNR85IA.Services
                 CarClassShortName = GetStr(node, "CarClassShortName"),
                 CarClassRelSpeed  = GetFloat(node, "CarClassRelSpeed"),
                 CarClassEstLapTime = GetFloat(node, "CarClassEstLapTime"),
-                TireCompound      = GetTireCompound(node)
+                TireCompound      = GetTireCompound(node),
+                TeamIncidentCount = GetInt(node, "TeamIncidentCount")
             };
         }
 
@@ -97,7 +98,8 @@ namespace SuperBackendNR85IA.Services
                     CarClassShortName = GetStr(child, "CarClassShortName"),
                     CarClassRelSpeed  = GetFloat(child, "CarClassRelSpeed"),
                     CarClassEstLapTime = GetFloat(child, "CarClassEstLapTime"),
-                    TireCompound      = GetTireCompound(child)
+                    TireCompound      = GetTireCompound(child),
+                    TeamIncidentCount = GetInt(child, "TeamIncidentCount")
                 });
             }
 
@@ -165,12 +167,15 @@ namespace SuperBackendNR85IA.Services
                                       .Select(p => new ResultPosition
                                       {
                                           Position = GetInt(p, "Position"),
-                                          CarIdx = GetInt(p, "CarIdx"),
-                                          FastestTime = GetFloat(p, "FastestTime"),
-                                          LastTime = GetFloat(p, "LastTime"),
-                                          OnPitRoad = GetBool(p, "OnPitRoad"),
-                                          InGarage = GetBool(p, "InGarage"),
-                                          PitStopCount = GetInt(p, "PitStopCount")
+                                      CarIdx = GetInt(p, "CarIdx"),
+                                      FastestTime = GetFloat(p, "FastestTime"),
+                                      LastTime = GetFloat(p, "LastTime"),
+                                      Time = GetFloat(p, "Time"),
+                                      Interval = GetFloat(p, "Interval"),
+                                      OnPitRoad = GetBool(p, "OnPitRoad"),
+                                      InGarage = GetBool(p, "InGarage"),
+                                      PitStopCount = GetInt(p, "PitStopCount"),
+                                      NewIRating = GetInt(p, "NewIRating")
                                       }).ToList();
                               }
                               return sd;


### PR DESCRIPTION
## Summary
- add `TeamIncidentCount` to `DriverInfo`
- add race result fields to `ResultPosition`
- parse newly added fields in `SessionYamlParser`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f91ce09588330a8177cb7641fc653