### PR TITLE
Optimize Inputs overlay payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This project contains a .NET backend that streams telemetry data through WebSock
 ```
 
 This starts the WebSocket server on `http://0.0.0.0:5221` (or the value of the `BACKEND_BIND_URL` environment variable). Overlays connect to the `/ws` endpoint on that port. You can provide a custom WebSocket URL to the overlays by setting the environment variable `OVERLAY_WS_URL` before launching the Electron app or by defining `window.OVERLAY_WS_URL` in a browser. If you need to bind to a different address/port, set `BACKEND_BIND_URL` before running the backend.
+Each overlay may also specify `?overlay=name` in the WebSocket URL to request a reduced payload optimized for that overlay.
 
 ## Running the Electron frontend
 

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -38,7 +38,8 @@ app.Map("/ws", async context =>
     {
         var webSocket = await context.WebSockets.AcceptWebSocketAsync();
         var handler = context.RequestServices.GetRequiredService<TelemetryBroadcaster>();
-        await handler.AddClient(webSocket, context.RequestAborted); // passa o CancellationToken para permitir cancelamento gracioso
+        var overlay = context.Request.Query["overlay"].ToString();
+        await handler.AddClient(webSocket, overlay, context.RequestAborted); // passa o CancellationToken para permitir cancelamento gracioso
     }
     else
     {

--- a/backend/Services/IRacingTelemetryService.cs
+++ b/backend/Services/IRacingTelemetryService.cs
@@ -146,7 +146,8 @@ namespace SuperBackendNR85IA.Services
                             TelemetryCalculations.SanitizeModel(telemetryModel);
 
                             var payload = BuildFrontendPayload(telemetryModel);
-                            await _broadcaster.BroadcastTelemetry(payload);
+                            var inputsPayload = BuildInputsPayload(telemetryModel);
+                            await _broadcaster.BroadcastTelemetry(payload, inputsPayload);
                         }
                         _lastTick = _sdk.Data.TickCount;
                     }
@@ -424,6 +425,17 @@ namespace SuperBackendNR85IA.Services
             payload["telemetry"] = t;
 
             return payload;
+        }
+
+        private object BuildInputsPayload(TelemetryModel t)
+        {
+            return new
+            {
+                throttle = t.Throttle,
+                brake = t.Brake,
+                steeringWheelAngle = t.SteeringWheelAngle,
+                gear = t.Gear
+            };
         }
 
         private void StartSdkWithFlags()

--- a/telemetry-frontend/public/overlay-common.js
+++ b/telemetry-frontend/public/overlay-common.js
@@ -5,8 +5,9 @@ function overlayHost() {
   return host && host.length > 0 ? host : 'localhost';
 }
 
-function initOverlayWebSocket(onData) {
-  const url = window.OVERLAY_WS_URL || `ws://${overlayHost()}:5221/ws`;
+function initOverlayWebSocket(onData, params = {}) {
+  const query = Object.keys(params).length > 0 ? '?' + new URLSearchParams(params).toString() : '';
+  const url = (window.OVERLAY_WS_URL || `ws://${overlayHost()}:5221/ws`) + query;
   console.log('[Overlay] connecting to', url);
   function connect() {
     socket = new WebSocket(url);

--- a/telemetry-frontend/public/overlays/overlay-inputs.html
+++ b/telemetry-frontend/public/overlays/overlay-inputs.html
@@ -730,7 +730,7 @@
                     latestData = data;
                     hasNewData = true;
                 }
-            });
+            }, { overlay: 'inputs' });
             function animationLoop() {
                 if (hasNewData && latestData) {
                     updateOverlayData(latestData);


### PR DESCRIPTION
## Summary
- allow overlays to specify `?overlay=name` in WebSocket URL
- add new `inputs` payload type in backend
- broadcast reduced messages to `overlay=inputs` clients
- update Inputs overlay and common JS
- document overlay query parameter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f9d4cc7d48330bb536a0c5c1f3d5e