### PR TITLE
Fix build by removing unused dependency

### DIFF
--- a/backend/SuperBackendNR85IA.csproj
+++ b/backend/SuperBackendNR85IA.csproj
@@ -9,6 +9,5 @@
     <PackageReference Include="Aydsko.iRacingData" Version="2502.0.0" />
     <PackageReference Include="IRSDKSharper" Version="1.1.3" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
-    <PackageReference Include="iRacingSdkWrapper" Version="1.1.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- remove the iRacingSdkWrapper package reference from the backend project since it isn't used anywhere

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850ba976d448330ae01c0178ed873d3