### PR TITLE
Fix build error in TireDataCollector

### DIFF
--- a/backend/Collectors/TireDataCollector.cs
+++ b/backend/Collectors/TireDataCollector.cs
@@ -41,7 +41,7 @@ namespace SuperBackendNR85IA.Collectors
         private string _currentTireCompound = "Unknown";
 
         // Desserializador para o YAML da SessionInfo
-        private IDeserializer _sessionInfoDeserializ
+        private IDeserializer _sessionInfoDeserializer;
         
         public TireDataCollector(Services.TelemetryBroadcaster broadcaster)
         {


### PR DESCRIPTION
## Summary
- fix variable declaration in `TireDataCollector` so the project builds

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850d6b9ab288330b4692c2d2f590013