### PR TITLE
Fix IRSDKSharp references

### DIFF
--- a/backend/Collectors/TireDataCollector.cs
+++ b/backend/Collectors/TireDataCollector.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using irsdksharper; // Usando irsdksharper
+using IRSDKSharper; // Usando IRSDKSharper
 using Microsoft.Extensions.Hosting;
 using SuperBackendNR85IA.Services;
 using YamlDotNet.Serialization;
@@ -18,7 +18,7 @@ namespace SuperBackendNR85IA.Collectors
     public class TireDataCollector : BackgroundService
     {
         private readonly Services.TelemetryBroadcaster _broadcaster;
-        private IrSdkClient irsdkClient;
+        private IRacingSdk irsdkClient;
         private CancellationTokenSource cancellationTokenSource;
         private List<TelemetrySnapshot> telemetryBatch;
         private readonly int batchSize = 30;
@@ -46,7 +46,7 @@ namespace SuperBackendNR85IA.Collectors
         public TireDataCollector(Services.TelemetryBroadcaster broadcaster)
         {
             _broadcaster = broadcaster;
-            irsdkClient = new IrSdkClient();
+            irsdkClient = new IRacingSdk();
             irsdkClient.OnNewData += OnTelemetryUpdated;
             irsdkClient.OnSessionInfoUpdated += OnSessionInfoUpdated;
             irsdkClient.OnConnected += OnConnected;


### PR DESCRIPTION
## Summary
- fix incorrect namespace casing in TireDataCollector
- use `IRacingSdk` type from IRSDKSharper

## Testing
- `dotnet restore` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6850d862aa448330ac1f99e052ae2e27