### PR TITLE
Add tire snapshot model

### DIFF
--- a/backend/Services/IRacingTelemetryService.Snapshot.cs
+++ b/backend/Services/IRacingTelemetryService.Snapshot.cs
@@ -1,0 +1,84 @@
+using System;
+using SuperBackendNR85IA.Models;
+using SuperBackendNR85IA.Snapshots;
+
+namespace SuperBackendNR85IA.Services
+{
+    public sealed partial class IRacingTelemetryService
+    {
+        private TelemetrySnapshot BuildTelemetrySnapshot(TelemetryModel t)
+        {
+            TireData Map(
+                float press, float lastHotPress, float coldPress,
+                float tempL, float tempM, float tempR,
+                float lastHotL, float lastHotM, float lastHotR,
+                float coldL, float coldM, float coldR,
+                float tread, float startTread)
+            {
+                return new TireData
+                {
+                    CurrentPressure = press,
+                    LastHotPressure = lastHotPress,
+                    ColdPressure = coldPress,
+                    CurrentTempInternal = tempL,
+                    CurrentTempMiddle = tempM,
+                    CurrentTempExternal = tempR,
+                    CoreTemp = (tempL + tempM + tempR) / 3f,
+                    LastHotTemp = (lastHotL + lastHotM + lastHotR) / 3f,
+                    ColdTemp = (coldL + coldM + coldR) / 3f,
+                    Wear = startTread > 0f ? 1f - tread / startTread : 0f,
+                    TreadRemaining = tread,
+                    SlipAngle = 0f,
+                    SlipRatio = 0f,
+                    Load = 0f,
+                    Deflection = 0f,
+                    RollVelocity = 0f,
+                    GroundVelocity = 0f,
+                    LateralForce = 0f,
+                    LongitudinalForce = 0f
+                };
+            }
+
+            var fl = Map(t.LfPress, t.LfLastHotPress, t.LfColdPress,
+                t.LfTempCl, t.LfTempCm, t.LfTempCr,
+                t.LfLastTempCl, t.LfLastTempCm, t.LfLastTempCr,
+                t.LfColdTempCl, t.LfColdTempCm, t.LfColdTempCr,
+                t.TreadRemainingFl, t.StartTreadFl);
+
+            var fr = Map(t.RfPress, t.RfLastHotPress, t.RfColdPress,
+                t.RfTempCl, t.RfTempCm, t.RfTempCr,
+                t.RfLastTempCl, t.RfLastTempCm, t.RfLastTempCr,
+                t.RfColdTempCl, t.RfColdTempCm, t.RfColdTempCr,
+                t.TreadRemainingFr, t.StartTreadFr);
+
+            var rl = Map(t.LrPress, t.LrLastHotPress, t.LrColdPress,
+                t.LrTempCl, t.LrTempCm, t.LrTempCr,
+                t.LrLastTempCl, t.LrLastTempCm, t.LrLastTempCr,
+                t.LrColdTempCl, t.LrColdTempCm, t.LrColdTempCr,
+                t.TreadRemainingRl, t.StartTreadRl);
+
+            var rr = Map(t.RrPress, t.RrLastHotPress, t.RrColdPress,
+                t.RrTempCl, t.RrTempCm, t.RrTempCr,
+                t.RrLastTempCl, t.RrLastTempCm, t.RrLastTempCr,
+                t.RrColdTempCl, t.RrColdTempCm, t.RrColdTempCr,
+                t.TreadRemainingRr, t.StartTreadRr);
+
+            return new TelemetrySnapshot
+            {
+                Timestamp = DateTime.UtcNow,
+                LapNumber = t.Lap,
+                LapDistance = t.LapDistPct,
+                FrontLeftTire = fl,
+                FrontRightTire = fr,
+                RearLeftTire = rl,
+                RearRightTire = rr,
+                Speed = t.Speed,
+                Rpm = t.Rpm,
+                VerticalAcceleration = t.VertAccel,
+                LateralAcceleration = t.LatAccel,
+                LongitudinalAcceleration = t.LonAccel,
+                TireCompound = t.TireCompound
+            };
+        }
+    }
+}

--- a/backend/Services/IRacingTelemetryService.cs
+++ b/backend/Services/IRacingTelemetryService.cs
@@ -421,6 +421,9 @@ namespace SuperBackendNR85IA.Services
                 payload[ToCamel(prop.Name)] = prop.GetValue(t);
             }
 
+            // Snapshot simplificado de pneus e dados principais
+            payload["tireSnapshot"] = BuildTelemetrySnapshot(t);
+
             // Preserve old property name for overlays that expect "telemetry"
             payload["telemetry"] = t;
 

--- a/backend/Snapshots/TelemetrySnapshot.cs
+++ b/backend/Snapshots/TelemetrySnapshot.cs
@@ -1,0 +1,29 @@
+// File: TelemetrySnapshot.cs
+using System;
+
+namespace SuperBackendNR85IA.Snapshots
+{
+    // Esta classe representa um "instantâneo" completo dos dados de telemetria em um ponto no tempo.
+    public class TelemetrySnapshot
+    {
+        public DateTime Timestamp { get; set; } // Momento em que o snapshot foi capturado (UTC)
+        public int LapNumber { get; set; }      // Número da volta atual
+        public float LapDistance { get; set; } // Distância percorrida na volta atual (0.0 a 1.0)
+
+        // Dados detalhados de cada pneu, usando a classe TireData
+        public TireData FrontLeftTire { get; set; } = new TireData();
+        public TireData FrontRightTire { get; set; } = new TireData();
+        public TireData RearLeftTire { get; set; } = new TireData();
+        public TireData RearRightTire { get; set; } = new TireData();
+
+        // Dados gerais do carro
+        public float Speed { get; set; }               // Velocidade do carro (metros/segundo)
+        public float Rpm { get; set; }                 // Rotações por minuto do motor
+        public float VerticalAcceleration { get; set; } // Aceleração vertical (para inferir vibração)
+        public float LateralAcceleration { get; set; }  // Aceleração lateral
+        public float LongitudinalAcceleration { get; set; } // Aceleração longitudinal
+
+        // Composto de pneu (incluído aqui para conveniência, mas idealmente seria metadado da sessão)
+        public string TireCompound { get; set; } = string.Empty;
+    }
+}

--- a/backend/Snapshots/TireData.cs
+++ b/backend/Snapshots/TireData.cs
@@ -1,0 +1,33 @@
+namespace SuperBackendNR85IA.Snapshots
+{
+    // Esta classe representa todos os dados de um único pneu em um determinado instante.
+    public class TireData
+    {
+        // Pressões (geralmente em psi ou kPa, dependendo da configuração do iRacing)
+        public float CurrentPressure { get; set; }     // Pressão atual do pneu
+        public float LastHotPressure { get; set; }     // Última pressão quente registrada (após o carro parar ou pit stop)
+        public float ColdPressure { get; set; }        // Pressão fria inferida (capturada quando o carro está parado no box)
+
+        // Temperaturas (geralmente em Celsius)
+        public float CurrentTempInternal { get; set; } // Temperatura da banda de rodagem - lado interno (TireTempL)
+        public float CurrentTempMiddle { get; set; }   // Temperatura da banda de rodagem - meio (TireTempM)
+        public float CurrentTempExternal { get; set; } // Temperatura da banda de rodagem - lado externo (TireTempR)
+        public float CoreTemp { get; set; }            // Temperatura do núcleo do pneu (TireTempCore)
+        public float LastHotTemp { get; set; }         // Última temperatura quente registrada (TireLFLastHotTemp, etc.)
+        public float ColdTemp { get; set; }            // Temperatura fria inferida (capturada quando o carro está parado no box)
+
+        // Desgaste e Borracha Restante (valores de 0.0 a 1.0)
+        public float Wear { get; set; }                // Desgaste do pneu (0.0 = novo, 1.0 = 100% desgastado)
+        public float TreadRemaining { get; set; }      // Borracha restante (1.0 = 100% restante, 0.0 = 0% restante)
+
+        // Dinâmica do Pneu
+        public float SlipAngle { get; set; }           // Ângulo de deslizamento do pneu (radianos)
+        public float SlipRatio { get; set; }           // Razão de deslizamento do pneu
+        public float Load { get; set; }                // Carga vertical no pneu (Newtons)
+        public float Deflection { get; set; }          // Deflexão/compressão do pneu (metros)
+        public float RollVelocity { get; set; }        // Velocidade de rotação do pneu (radianos/segundo)
+        public float GroundVelocity { get; set; }      // Velocidade do pneu em relação ao solo (metros/segundo)
+        public float LateralForce { get; set; }        // Força lateral gerada pelo pneu (Newtons)
+        public float LongitudinalForce { get; set; }   // Força longitudinal gerada pelo pneu (Newtons)
+    }
+}


### PR DESCRIPTION
## Summary
- revert erroneous TyreData change
- add simplified `TireData` and `TelemetrySnapshot` models
- expose `tireSnapshot` payload via `IRacingTelemetryService`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850e21d4950833087688a44b9606326