### PR TITLE
Add Tires YAML overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,18 @@ Each overlay corresponds to an HTML file in `telemetry-frontend/public/overlays`
 - **Radar** – circular radar indicating nearby cars with alerts.
 - **Teste Final** – diagnostic overlay combining various widgets.
 - **Tires Raw** – displays every tire-related value received from iRacing.
+- **Tires YAML** – parses `yamls/input_current.yaml` and lists tire values.
 - **Dados Completos** – shows all backend data, including the raw YAML and parsed fields.
 
 More details sobre os dados de pneus necessários podem ser encontrados em
 `docs/overlay-tires-checklist.md`.
 
 To open an overlay, start the Electron application and click its name in the menu. Windows can be moved, pinned or closed individually.
+You can also launch an overlay directly by passing `--open=<file>` to Electron. For convenience a script is provided:
+
+```bash
+npm run open:tiresyaml
+```
 
 ## Tests
 

--- a/telemetry-frontend/main.cjs
+++ b/telemetry-frontend/main.cjs
@@ -106,7 +106,19 @@ ipcMain.handle('overlay-is-destroyed', (e, id) => {
   return true;
 });
 
-app.whenReady().then(createMainWindow);
+function openOverlayFromCli() {
+  const arg = process.argv.find(a => a.startsWith('--open='));
+  if (!arg) return;
+  const file = arg.split('=')[1];
+  if (!file) return;
+  const name = file.replace(/\.html$/i, '');
+  createOverlay(name, file);
+}
+
+app.whenReady().then(() => {
+  createMainWindow();
+  openOverlayFromCli();
+});
 app.on('activate', () => BrowserWindow.getAllWindows().length === 0 && createMainWindow());
 app.on('window-all-closed', () => {
   for (const [, win] of overlays) {

--- a/telemetry-frontend/package.json
+++ b/telemetry-frontend/package.json
@@ -11,6 +11,7 @@
     "dev": "concurrently \"npm run backend\" \"npm run dev:vite\" \"npm run dev:electron\"",
     "build": "vite build",
     "start": "electron .",
+    "open:tiresyaml": "electron . --open=overlay-tiresyaml.html",
     "preview": "vite preview",
     "test": "echo \"No tests configured\""
   },

--- a/telemetry-frontend/public/menu.html
+++ b/telemetry-frontend/public/menu.html
@@ -35,6 +35,7 @@
    <button onclick="abrir('overlay-tanque.html','tanque')"><i class="fas fa-tachometer-alt"></i> Tanque</button>
    <button onclick="abrir('overlay-tiresandbrakes.html','tiresandbrakes')"><i class="fas fa-car"></i> Pneus & Freios</button>
    <button onclick="abrir('overlay-tiresgarage.html','tiresgarage')"><i class="fas fa-warehouse"></i> Pneus Garagem</button>
+   <button onclick="abrir('overlay-tiresyaml.html','tiresyaml')"><i class="fas fa-file-code"></i> Pneus YAML</button>
    <button onclick="abrir('overlay-relative.html','relative')"><i class="fas fa-ruler-combined"></i> Relative</button>
    <button onclick="abrir('overlay-radar.html','radar')"><i class="fas fa-bullseye"></i> Radar</button>
    <button onclick="abrir('overlay-sessao.html','sessao')"><i class="fas fa-clock"></i> Sessão</button>

--- a/telemetry-frontend/public/overlays/overlay-tiresyaml.html
+++ b/telemetry-frontend/public/overlays/overlay-tiresyaml.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tires YAML Viewer</title>
+  <script src="https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/dist/js-yaml.min.js"></script>
+  <style>
+    body { background:#111; color:#e2e8f0; font-family: monospace; margin:0; }
+    table { border-collapse: collapse; margin:0.5rem; }
+    th, td { border:1px solid #555; padding:4px; }
+    th { text-align:left; background:#222; }
+  </style>
+</head>
+<body>
+<table id="tire-table">
+  <thead><tr><th>Field</th><th>Value</th></tr></thead>
+  <tbody><tr><td colspan="2">Carregando...</td></tr></tbody>
+</table>
+<script type="module">
+  const tableBody = document.querySelector('#tire-table tbody');
+  async function fetchYaml() {
+    try {
+      const res = await fetch('/yamls/input_current.yaml');
+      if (!res.ok) throw new Error('HTTP ' + res.status);
+      const text = await res.text();
+      const data = jsyaml.load(text);
+      let tires = null;
+      try {
+        tires = data?.DriverInfo?.Drivers?.[0]?.CarSetup?.Tires;
+      } catch (err) {}
+      if (!tires) {
+        tableBody.innerHTML = '<tr><td colspan="2">Dados de pneus não encontrados</td></tr>';
+        return;
+      }
+      tableBody.innerHTML = '';
+      for (const [key, val] of Object.entries(tires)) {
+        const tr = document.createElement('tr');
+        const tdKey = document.createElement('td');
+        const tdVal = document.createElement('td');
+        tdKey.textContent = key;
+        tdVal.textContent = Array.isArray(val) ? val.join(', ') : val;
+        tr.append(tdKey, tdVal);
+        tableBody.appendChild(tr);
+      }
+    } catch (err) {
+      console.error('Fetch YAML', err);
+      tableBody.innerHTML = '<tr><td colspan="2">Erro ao carregar YAML</td></tr>';
+    }
+  }
+  fetchYaml();
+  setInterval(fetchYaml, 5000);
+</script>
+</body>
+</html>

--- a/telemetry-frontend/src/overlayList.js
+++ b/telemetry-frontend/src/overlayList.js
@@ -13,6 +13,7 @@ export default [
   { name: 'Teste Final', file: 'overlay-testefinal.html' },
   { name: 'Diagnóstico Raw', file: 'overlay-diagnostico-raw.html' },
   { name: 'Tires Raw', file: 'overlay-tiresraw.html' },
+  { name: 'Tires YAML', file: 'overlay-tiresyaml.html' },
   { name: 'Dados Completos', file: 'overlay-dadoscompletos.html' },
   { name: 'Tire Snapshot', file: 'overlay-tiresnapshot.html' }
 ];


### PR DESCRIPTION
## Summary
- add overlay to parse the YAML data file for tire fields
- expose new entry on menu and overlay list
- allow launching overlays via `--open=<file>` argument

## Testing
- `npm test --prefix telemetry-frontend`


------
https://chatgpt.com/codex/tasks/task_e_685206ef42848330b924cad70fc52ad0