### PR TITLE
Refactor telemetry loop and validation

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -14,7 +14,7 @@ builder.WebHost.UseUrls("http://localhost:5221");
 
 // DI ------------------------------------------------------------------------
 builder.Services.AddSingleton<TelemetryBroadcaster>();
-builder.Services.AddSingleton<CarTrackDataStore>();
+builder.Services.AddSingleton<Repositories.ICarTrackRepository, CarTrackDataStore>();
 builder.Services.AddSingleton<SessionYamlParser>();
 builder.Services.AddHostedService<IRacingTelemetryService>();
 

--- a/backend/Repositories/ICarTrackRepository.cs
+++ b/backend/Repositories/ICarTrackRepository.cs
@@ -1,0 +1,9 @@
+namespace SuperBackendNR85IA.Repositories
+{
+    public interface ICarTrackRepository
+    {
+        Task<Services.CarTrackData> GetAsync(string carPath, string trackName);
+        Task UpdateAsync(Services.CarTrackData data);
+    }
+}
+

--- a/backend/Services/CarTrackDataStore.cs
+++ b/backend/Services/CarTrackDataStore.cs
@@ -15,7 +15,7 @@ namespace SuperBackendNR85IA.Services
         public float FuelCapacity { get; set; }
     }
 
-    public class CarTrackDataStore
+    public class CarTrackDataStore : Repositories.ICarTrackRepository
     {
         // Caminho para armazenamento do JSON contendo dados por carro/pista
         private readonly string _filePath;

--- a/backend/Services/IRacingTelemetryService.Data.cs
+++ b/backend/Services/IRacingTelemetryService.Data.cs
@@ -328,6 +328,7 @@ namespace SuperBackendNR85IA.Services
                 _log.LogWarning($"Negative SessionTime received: {rawSessionTime}");
                 rawSessionTime = 0.0;
             }
+            rawSessionTime = Utilities.DataValidator.EnsurePositive(rawSessionTime);
 
             if (_log.IsEnabled(LogLevel.Debug))
                 _log.LogDebug($"Raw SessionTime: {rawSessionTime}");

--- a/backend/Services/IRacingTelemetryService.cs
+++ b/backend/Services/IRacingTelemetryService.cs
@@ -31,7 +31,7 @@ namespace SuperBackendNR85IA.Services
         private float _consumoUltimaVolta = 0f;
         private readonly Queue<float> _ultimoConsumoVoltas = new();
         private int _lastSessionNum = -1;
-        private readonly CarTrackDataStore _store;
+        private readonly Repositories.ICarTrackRepository _store;
         private string _carPath = string.Empty;
         private string _trackName = string.Empty;
         private bool _awaitingStoredData = false;
@@ -94,7 +94,7 @@ namespace SuperBackendNR85IA.Services
         public IRacingTelemetryService(
             ILogger<IRacingTelemetryService> log,
             TelemetryBroadcaster broadcaster,
-            CarTrackDataStore store,
+            Repositories.ICarTrackRepository store,
             SessionYamlParser yamlParser)
         {
             _log = log;
@@ -123,15 +123,14 @@ namespace SuperBackendNR85IA.Services
                 return;
             }
 
-            while (!ct.IsCancellationRequested)
+            using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(TICK_MS));
+
+            while (await timer.WaitForNextTickAsync(ct))
             {
                 try
                 {
                     if (!_sdk.IsConnected || !_sdk.IsStarted)
-                    {
-                        await Task.Delay(1000, ct);
                         continue;
-                    }
 
                     if (!_loggedAvailableVars && _sdk.Data != null)
                     {
@@ -142,7 +141,7 @@ namespace SuperBackendNR85IA.Services
 
                     if (_sdk.Data != null && _sdk.Data.TickCount != _lastTick)
                     {
-                        var telemetryModel = await BuildTelemetryModelAsync();
+                        var telemetryModel = await BuildTelemetryModelAsync(ct);
                         if (telemetryModel != null)
                         {
                             TelemetryCalculationsOverlay.PreencherOverlayTanque(ref telemetryModel);
@@ -158,11 +157,14 @@ namespace SuperBackendNR85IA.Services
                         _lastTick = _sdk.Data.TickCount;
                     }
                 }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    break;
+                }
                 catch (Exception ex)
                 {
                     _log.LogError(ex, "Erro no loop principal de telemetria.");
                 }
-                await Task.Delay(TICK_MS, ct);
             }
 
             _log.LogInformation("IRacingTelemetryService está parando.");
@@ -170,7 +172,7 @@ namespace SuperBackendNR85IA.Services
         }
 
 
-        private async Task<TelemetryModel?> BuildTelemetryModelAsync()
+        private async Task<TelemetryModel?> BuildTelemetryModelAsync(CancellationToken ct)
         {
             if (_sdk.Data == null) return null;
 

--- a/backend/Utilities/DataValidator.cs
+++ b/backend/Utilities/DataValidator.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace SuperBackendNR85IA.Utilities
+{
+    public static class DataValidator
+    {
+        public static float EnsurePositive(float value)
+        {
+            return float.IsNaN(value) || float.IsInfinity(value) || value < 0f ? 0f : value;
+        }
+
+        public static double EnsurePositive(double value)
+        {
+            return double.IsNaN(value) || double.IsInfinity(value) || value < 0.0 ? 0.0 : value;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- use PeriodicTimer to drive telemetry loop
- allow cancellation token in `BuildTelemetryModelAsync`
- add `DataValidator` utility with positive checks
- validate session time using new helper
- introduce car track repository interface
- register interface in DI and refactor telemetry service dependency

## Testing
- `dotnet build` *(fails: command not found)*
- `npm test --prefix telemetry-frontend`

------
https://chatgpt.com/codex/tasks/task_e_6852acb325648330b06903e44f9cdb23