### PR TITLE
Expose missing SDK variables

### DIFF
--- a/backend/Services/IRacingTelemetryService.cs
+++ b/backend/Services/IRacingTelemetryService.cs
@@ -425,7 +425,7 @@ namespace SuperBackendNR85IA.Services
 
         private Dictionary<string, object?> BuildFrontendPayload(TelemetryModel t)
         {
-            var payload = new Dictionary<string, object?>(_telemetryProps.Length + 2);
+            var payload = new Dictionary<string, object?>(_telemetryProps.Length + 3);
             for (int i = 0; i < _telemetryProps.Length; i++)
             {
                 payload[_telemetryPropNames[i]] = _telemetryProps[i].GetValue(t);
@@ -436,6 +436,9 @@ namespace SuperBackendNR85IA.Services
 
             // Preserve old property name for overlays that expect "telemetry"
             payload["telemetry"] = t;
+
+            // Inform clients which SDK variables are missing
+            payload["missingVars"] = _missingVarWarned.ToArray();
 
             return payload;
         }


### PR DESCRIPTION
## Summary
- show missing telemetry variable names as warnings again
- send `missingVars` array with websocket payloads so clients can see which SDK values are unavailable

## Testing
- `npm test` (no tests configured)
- `dotnet test backend/SuperBackendNR85IA.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852344a18748330936d1bb6c1dc255f