### PR TITLE
Refine services and enums

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -14,7 +14,7 @@ builder.WebHost.UseUrls("http://localhost:5221");
 
 // DI ------------------------------------------------------------------------
 builder.Services.AddSingleton<TelemetryBroadcaster>();
-builder.Services.AddSingleton<CarTrackDataStore>();
+builder.Services.AddSingleton<Repositories.ICarTrackRepository, CarTrackDataStore>();
 builder.Services.AddSingleton<SessionYamlParser>();
 builder.Services.AddHostedService<IRacingTelemetryService>();
 

--- a/backend/Repositories/ICarTrackRepository.cs
+++ b/backend/Repositories/ICarTrackRepository.cs
@@ -1,0 +1,9 @@
+namespace SuperBackendNR85IA.Repositories
+{
+    public interface ICarTrackRepository
+    {
+        Task<Services.CarTrackData> GetAsync(string carPath, string trackName);
+        Task UpdateAsync(Services.CarTrackData data);
+    }
+}
+

--- a/backend/Services/CarTrackDataStore.cs
+++ b/backend/Services/CarTrackDataStore.cs
@@ -15,7 +15,7 @@ namespace SuperBackendNR85IA.Services
         public float FuelCapacity { get; set; }
     }
 
-    public class CarTrackDataStore
+    public class CarTrackDataStore : Repositories.ICarTrackRepository
     {
         // Caminho para armazenamento do JSON contendo dados por carro/pista
         private readonly string _filePath;
@@ -24,7 +24,6 @@ namespace SuperBackendNR85IA.Services
 
         public CarTrackDataStore(IConfiguration configuration)
         {
-            // Usa caminho configurado ou cai no diretório atual caso não exista
             var configured = configuration["CarTrackStorePath"];
             _filePath = string.IsNullOrWhiteSpace(configured)
                 ? Path.Combine(AppContext.BaseDirectory, "carTrackData.json")
@@ -33,26 +32,34 @@ namespace SuperBackendNR85IA.Services
             try
             {
                 if (File.Exists(_filePath))
-                {                    
+                {
                     var json = File.ReadAllText(_filePath);
                     _data = JsonSerializer.Deserialize<Dictionary<string, CarTrackData>>(json) ?? new();
                 }
             }
-            catch { _data = new(); }
+            catch
+            {
+                _data = new();
+            }
         }
 
         private string Key(string carPath, string trackName) => $"{carPath}::{trackName}";
+
+        private CarTrackData GetOrCreate(string carPath, string trackName)
+        {
+            var key = Key(carPath, trackName);
+            if (_data.TryGetValue(key, out var d))
+                return d;
+            d = new CarTrackData { CarPath = carPath, TrackName = trackName };
+            _data[key] = d;
+            return d;
+        }
 
         public CarTrackData Get(string carPath, string trackName)
         {
             lock (_lock)
             {
-                var key = Key(carPath, trackName);
-                if (_data.TryGetValue(key, out var d))
-                    return d;
-                d = new CarTrackData { CarPath = carPath, TrackName = trackName };
-                _data[key] = d;
-                return d;
+                return GetOrCreate(carPath, trackName);
             }
         }
 
@@ -75,12 +82,7 @@ namespace SuperBackendNR85IA.Services
         {
             lock (_lock)
             {
-                var key = Key(carPath, trackName);
-                if (_data.TryGetValue(key, out var d))
-                    return Task.FromResult(d);
-                d = new CarTrackData { CarPath = carPath, TrackName = trackName };
-                _data[key] = d;
-                return Task.FromResult(d);
+                return Task.FromResult(GetOrCreate(carPath, trackName));
             }
         }
 

--- a/backend/Services/EnumTranslations.cs
+++ b/backend/Services/EnumTranslations.cs
@@ -4,42 +4,45 @@ namespace SuperBackendNR85IA.Services
 {
     public static class EnumTranslations
     {
+        private static readonly Dictionary<int, string> SessionStates = new()
+        {
+            [0] = "Invalid",
+            [1] = "GetInCar",
+            [2] = "Warmup",
+            [3] = "ParadeLaps",
+            [4] = "Racing",
+            [5] = "Checkered",
+            [6] = "CoolDown"
+        };
+
         public static string TranslateSessionState(int state) =>
-            state switch
-            {
-                0 => "Invalid",
-                1 => "GetInCar",
-                2 => "Warmup",
-                3 => "ParadeLaps",
-                4 => "Racing",
-                5 => "Checkered",
-                6 => "CoolDown",
-                _ => "Unknown",
-            };
+            SessionStates.TryGetValue(state, out var s) ? s : "Unknown";
+
+        private static readonly Dictionary<int, string> PaceModes = new()
+        {
+            [0] = "SingleFileStart",
+            [1] = "DoubleFileStart",
+            [2] = "SingleFileRestart",
+            [3] = "DoubleFileRestart",
+            [4] = "NotPacing",
+            [5] = "Pacing",
+            [6] = "CautionLap",
+            [7] = "LastLap"
+        };
 
         public static string TranslatePaceMode(int mode) =>
-            mode switch
-            {
-                0 => "SingleFileStart",
-                1 => "DoubleFileStart",
-                2 => "SingleFileRestart",
-                3 => "DoubleFileRestart",
-                4 => "NotPacing",
-                5 => "Pacing",
-                6 => "CautionLap",
-                7 => "LastLap",
-                _ => "Unknown",
-            };
+            PaceModes.TryGetValue(mode, out var p) ? p : "Unknown";
+
+        private static readonly Dictionary<int, string> SkiesDict = new()
+        {
+            [0] = "Clear",
+            [1] = "Partly Cloudy",
+            [2] = "Mostly Cloudy",
+            [3] = "Overcast"
+        };
 
         public static string TranslateSkies(int skies) =>
-            skies switch
-            {
-                0 => "Clear",
-                1 => "Partly Cloudy",
-                2 => "Mostly Cloudy",
-                3 => "Overcast",
-                _ => "Unknown",
-            };
+            SkiesDict.TryGetValue(skies, out var s) ? s : "Unknown";
 
         public static List<string> TranslateSessionFlags(int flags)
         {

--- a/backend/Services/IRacingTelemetryService.AllExtras.cs
+++ b/backend/Services/IRacingTelemetryService.AllExtras.cs
@@ -7,6 +7,25 @@ namespace SuperBackendNR85IA.Services
 {
     public sealed partial class IRacingTelemetryService
     {
+        private float Pos(IRacingSdkData d, string name) =>
+            Utilities.DataValidator.EnsurePositive(GetSdkValue<float>(d, name) ?? 0f);
+
+        private int NonNeg(IRacingSdkData d, string name) =>
+            Utilities.DataValidator.EnsureNonNegative(GetSdkValue<int>(d, name) ?? 0);
+
+        private long NonNegLong(IRacingSdkData d, string name) =>
+            Utilities.DataValidator.EnsureNonNegative(GetSdkValue<long>(d, name) ?? 0);
+
+        private float[] PosArray(IRacingSdkData d, string name) =>
+            GetSdkArray<float>(d, name)
+                .Select(v => Utilities.DataValidator.EnsurePositive(v ?? 0f))
+                .ToArray();
+
+        private int[] NonNegArray(IRacingSdkData d, string name) =>
+            GetSdkArray<int>(d, name)
+                .Select(v => Utilities.DataValidator.EnsureNonNegative(v ?? 0))
+                .ToArray();
+
         private void PopulateAllExtraData(IRacingSdkData d, TelemetryModel t)
         {
             PopulateAdvancedVehicleData(d, t);
@@ -22,108 +41,108 @@ namespace SuperBackendNR85IA.Services
 
         private void PopulateAdvancedVehicleData(IRacingSdkData d, TelemetryModel t)
         {
-            t.Vehicle.ThrottleRaw = GetSdkValue<float>(d, "ThrottleRaw") ?? 0f;
-            t.Vehicle.BrakeRaw = GetSdkValue<float>(d, "BrakeRaw") ?? 0f;
-            t.Vehicle.HandBrake = GetSdkValue<float>(d, "HandBrake") ?? 0f;
-            t.Vehicle.HandBrakeRaw = GetSdkValue<float>(d, "HandBrakeRaw") ?? 0f;
-            t.Vehicle.SteeringWheelPctTorque = GetSdkValue<float>(d, "SteeringWheelPctTorque") ?? 0f;
-            t.Vehicle.SteeringWheelLimiter = GetSdkValue<int>(d, "SteeringWheelLimiter") ?? 0;
-            t.Vehicle.SteeringWheelPeakForceNm = GetSdkValue<float>(d, "SteeringWheelPeakForceNm") ?? 0f;
-            t.Vehicle.Voltage = GetSdkValue<float>(d, "Voltage") ?? 0f;
-            t.Vehicle.OilLevel = GetSdkValue<float>(d, "OilLevel") ?? 0f;
-            t.Vehicle.WaterLevel = GetSdkValue<float>(d, "WaterLevel") ?? 0f;
+            t.Vehicle.ThrottleRaw = Pos(d, "ThrottleRaw");
+            t.Vehicle.BrakeRaw = Pos(d, "BrakeRaw");
+            t.Vehicle.HandBrake = Pos(d, "HandBrake");
+            t.Vehicle.HandBrakeRaw = Pos(d, "HandBrakeRaw");
+            t.Vehicle.SteeringWheelPctTorque = Pos(d, "SteeringWheelPctTorque");
+            t.Vehicle.SteeringWheelLimiter = NonNeg(d, "SteeringWheelLimiter");
+            t.Vehicle.SteeringWheelPeakForceNm = Pos(d, "SteeringWheelPeakForceNm");
+            t.Vehicle.Voltage = Pos(d, "Voltage");
+            t.Vehicle.OilLevel = Pos(d, "OilLevel");
+            t.Vehicle.WaterLevel = Pos(d, "WaterLevel");
         }
 
         private void PopulateForceDetailData(IRacingSdkData d, TelemetryModel t)
         {
-            t.Vehicle.SteeringWheelPctTorqueSign = GetSdkValue<float>(d, "SteeringWheelPctTorqueSign") ?? 0f;
-            t.Vehicle.SteeringWheelPctTorqueSignStops = GetSdkValue<float>(d, "SteeringWheelPctTorqueSignStops") ?? 0f;
+            t.Vehicle.SteeringWheelPctTorqueSign = Pos(d, "SteeringWheelPctTorqueSign");
+            t.Vehicle.SteeringWheelPctTorqueSignStops = Pos(d, "SteeringWheelPctTorqueSignStops");
         }
 
         private void PopulatePowertrainData(IRacingSdkData d, TelemetryModel t)
         {
-            t.Powertrain.ShiftIndicatorPct = GetSdkValue<float>(d, "ShiftIndicatorPct") ?? 0f;
-            t.Powertrain.ShiftPowerPct = GetSdkValue<float>(d, "ShiftPowerPct") ?? 0f;
-            t.Powertrain.ShiftGrindRpm = GetSdkValue<float>(d, "ShiftGrindRPM") ?? 0f;
+            t.Powertrain.ShiftIndicatorPct = Pos(d, "ShiftIndicatorPct");
+            t.Powertrain.ShiftPowerPct = Pos(d, "ShiftPowerPct");
+            t.Powertrain.ShiftGrindRpm = Pos(d, "ShiftGrindRPM");
             t.Powertrain.ManualBoost = GetSdkValue<bool>(d, "ManualBoost") ?? false;
             t.Powertrain.ManualNoBoost = GetSdkValue<bool>(d, "ManualNoBoost") ?? false;
             t.Powertrain.PushToPass = GetSdkValue<bool>(d, "PushToPass") ?? false;
-            t.Powertrain.P2PCount = GetSdkValue<int>(d, "P2P_Count") ?? 0;
-            t.Powertrain.P2PStatus = GetSdkValue<int>(d, "P2P_Status") ?? 0;
-            t.Powertrain.EnergyErsBattery = GetSdkValue<float>(d, "EnergyERSBattery") ?? 0f;
-            t.Powertrain.EnergyErsBatteryPct = GetSdkValue<float>(d, "EnergyERSBatteryPct") ?? 0f;
-            t.Powertrain.EnergyBatteryToMguKLap = GetSdkValue<float>(d, "EnergyBatteryToMGU_KLap") ?? 0f;
-            t.Powertrain.EnergyMguKLapDeployPct = GetSdkValue<float>(d, "EnergyMGU_KLapDeployPct") ?? 0f;
+            t.Powertrain.P2PCount = NonNeg(d, "P2P_Count");
+            t.Powertrain.P2PStatus = NonNeg(d, "P2P_Status");
+            t.Powertrain.EnergyErsBattery = Pos(d, "EnergyERSBattery");
+            t.Powertrain.EnergyErsBatteryPct = Pos(d, "EnergyERSBatteryPct");
+            t.Powertrain.EnergyBatteryToMguKLap = Pos(d, "EnergyBatteryToMGU_KLap");
+            t.Powertrain.EnergyMguKLapDeployPct = Pos(d, "EnergyMGU_KLapDeployPct");
         }
 
         private void PopulatePitStrategyData(IRacingSdkData d, TelemetryModel t)
         {
-            t.Pit.PitSvFuel = GetSdkValue<float>(d, "PitSvFuel") ?? 0f;
-            t.Pit.PitSvFlags = GetSdkValue<int>(d, "PitSvFlags") ?? 0;
-            t.Pit.PitSvTireCompound = GetSdkValue<int>(d, "PitSvTireCompound") ?? 0;
-            t.Pit.PitSvLFP = GetSdkValue<float>(d, "PitSvLFP") ?? 0f;
-            t.Pit.PitSvLRP = GetSdkValue<float>(d, "PitSvLRP") ?? 0f;
-            t.Pit.PitSvRFP = GetSdkValue<float>(d, "PitSvRFP") ?? 0f;
-            t.Pit.PitSvRRP = GetSdkValue<float>(d, "PitSvRRP") ?? 0f;
-            t.Pit.FastRepairAvailable = GetSdkValue<int>(d, "FastRepairAvailable") ?? 0;
-            t.Pit.FastRepairUsed = GetSdkValue<int>(d, "FastRepairUsed") ?? 0;
+            t.Pit.PitSvFuel = Pos(d, "PitSvFuel");
+            t.Pit.PitSvFlags = NonNeg(d, "PitSvFlags");
+            t.Pit.PitSvTireCompound = NonNeg(d, "PitSvTireCompound");
+            t.Pit.PitSvLFP = Pos(d, "PitSvLFP");
+            t.Pit.PitSvLRP = Pos(d, "PitSvLRP");
+            t.Pit.PitSvRFP = Pos(d, "PitSvRFP");
+            t.Pit.PitSvRRP = Pos(d, "PitSvRRP");
+            t.Pit.FastRepairAvailable = NonNeg(d, "FastRepairAvailable");
+            t.Pit.FastRepairUsed = NonNeg(d, "FastRepairUsed");
             t.Pit.PlayerCarInPitStall = GetSdkValue<bool>(d, "PlayerCarInPitStall") ?? false;
         }
 
         private void PopulateSessionEnvironmentData(IRacingSdkData d, TelemetryModel t)
         {
-            t.Session.SessionUniqueID = GetSdkValue<long>(d, "SessionUniqueID") ?? 0;
-            t.Session.SessionTick = GetSdkValue<int>(d, "SessionTick") ?? 0;
-            t.Session.SessionTimeTotal = GetSdkValue<float>(d, "SessionTimeTotal") ?? 0f;
+            t.Session.SessionUniqueID = NonNegLong(d, "SessionUniqueID");
+            t.Session.SessionTick = NonNeg(d, "SessionTick");
+            t.Session.SessionTimeTotal = Pos(d, "SessionTimeTotal");
             t.Environment.WeatherDeclaredWet = GetSdkValue<bool>(d, "WeatherDeclaredWet") ?? false;
-            t.Environment.SolarAltitude = GetSdkValue<float>(d, "SolarAltitude") ?? 0f;
-            t.Environment.SolarAzimuth = GetSdkValue<float>(d, "SolarAzimuth") ?? 0f;
-            t.Environment.FogLevel = GetSdkValue<float>(d, "FogLevel") ?? 0f;
-            t.Environment.Precipitation = GetSdkValue<float>(d, "Precipitation") ?? 0f;
+            t.Environment.SolarAltitude = Pos(d, "SolarAltitude");
+            t.Environment.SolarAzimuth = Pos(d, "SolarAzimuth");
+            t.Environment.FogLevel = Pos(d, "FogLevel");
+            t.Environment.Precipitation = Pos(d, "Precipitation");
             t.Environment.TrackGripStatus = t.TrackGripStatus;
         }
 
         private void PopulateRadarExtraData(IRacingSdkData d, TelemetryModel t)
         {
-            t.Radar.CarIdxGear = GetSdkArray<int>(d, "CarIdxGear").Select(v => v ?? 0).ToArray();
-            t.Radar.CarIdxRPM = GetSdkArray<float>(d, "CarIdxRPM").Select(v => v ?? 0f).ToArray();
-            t.Radar.CarIdxSteer = GetSdkArray<float>(d, "CarIdxSteer").Select(v => v ?? 0f).ToArray();
-            t.Radar.CarIdxTrackSurfaceMaterial = GetSdkArray<int>(d, "CarIdxTrackSurfaceMaterial").Select(v => v ?? 0).ToArray();
-            t.Radar.CarIdxEstTime = GetSdkArray<float>(d, "CarIdxEstTime").Select(v => v ?? 0f).ToArray();
-            t.Radar.CarIdxPaceFlags = GetSdkArray<int>(d, "CarIdxPaceFlags").Select(v => v ?? 0).ToArray();
-            t.Radar.CarIdxPaceLine = GetSdkArray<int>(d, "CarIdxPaceLine").Select(v => v ?? 0).ToArray();
-            t.Radar.CarIdxPaceRow = GetSdkArray<int>(d, "CarIdxPaceRow").Select(v => v ?? 0).ToArray();
-            t.Radar.CarIdxFastRepairsUsed = GetSdkArray<int>(d, "CarIdxFastRepairsUsed").Select(v => v ?? 0).ToArray();
-            t.Radar.CarIdxTireCompound = GetSdkArray<int>(d, "CarIdxTireCompound").Select(v => v ?? 0).ToArray();
-            t.Radar.CarIdxPowerAdjust = GetSdkArray<float>(d, "CarIdxPowerAdjust").Select(v => v ?? 0f).ToArray();
-            t.Radar.CarIdxWeightPenalty = GetSdkArray<float>(d, "CarIdxWeightPenalty").Select(v => v ?? 0f).ToArray();
-            t.Radar.CarLeftRight = GetSdkValue<int>(d, "CarLeftRight") ?? 0;
+            t.Radar.CarIdxGear = NonNegArray(d, "CarIdxGear");
+            t.Radar.CarIdxRPM = PosArray(d, "CarIdxRPM");
+            t.Radar.CarIdxSteer = PosArray(d, "CarIdxSteer");
+            t.Radar.CarIdxTrackSurfaceMaterial = NonNegArray(d, "CarIdxTrackSurfaceMaterial");
+            t.Radar.CarIdxEstTime = PosArray(d, "CarIdxEstTime");
+            t.Radar.CarIdxPaceFlags = NonNegArray(d, "CarIdxPaceFlags");
+            t.Radar.CarIdxPaceLine = NonNegArray(d, "CarIdxPaceLine");
+            t.Radar.CarIdxPaceRow = NonNegArray(d, "CarIdxPaceRow");
+            t.Radar.CarIdxFastRepairsUsed = NonNegArray(d, "CarIdxFastRepairsUsed");
+            t.Radar.CarIdxTireCompound = NonNegArray(d, "CarIdxTireCompound");
+            t.Radar.CarIdxPowerAdjust = PosArray(d, "CarIdxPowerAdjust");
+            t.Radar.CarIdxWeightPenalty = PosArray(d, "CarIdxWeightPenalty");
+            t.Radar.CarLeftRight = NonNeg(d, "CarLeftRight");
         }
 
         private void PopulateSystemPerformanceData(IRacingSdkData d, TelemetryModel t)
         {
-            t.System.FrameRate = GetSdkValue<float>(d, "FrameRate") ?? 0f;
-            t.System.CpuUsageFg = GetSdkValue<float>(d, "CpuUsageFG") ?? 0f;
-            t.System.CpuUsageBg = GetSdkValue<float>(d, "CpuUsageBG") ?? 0f;
-            t.System.GpuUsage = GetSdkValue<float>(d, "GpuUsage") ?? 0f;
-            t.System.ChanLatency = GetSdkValue<float>(d, "ChanLatency") ?? 0f;
-            t.System.ChanQuality = GetSdkValue<float>(d, "ChanQuality") ?? 0f;
-            t.System.ChanPartnerQuality = GetSdkValue<float>(d, "ChanPartnerQuality") ?? 0f;
-            t.System.ChanAvgLatency = GetSdkValue<float>(d, "ChanAvgLatency") ?? 0f;
-            t.System.ChanClockSkew = GetSdkValue<float>(d, "ChanClockSkew") ?? 0f;
+            t.System.FrameRate = Pos(d, "FrameRate");
+            t.System.CpuUsageFg = Pos(d, "CpuUsageFG");
+            t.System.CpuUsageBg = Pos(d, "CpuUsageBG");
+            t.System.GpuUsage = Pos(d, "GpuUsage");
+            t.System.ChanLatency = Pos(d, "ChanLatency");
+            t.System.ChanQuality = Pos(d, "ChanQuality");
+            t.System.ChanPartnerQuality = Pos(d, "ChanPartnerQuality");
+            t.System.ChanAvgLatency = Pos(d, "ChanAvgLatency");
+            t.System.ChanClockSkew = Pos(d, "ChanClockSkew");
         }
 
         private void PopulateHighFreqData(IRacingSdkData d, TelemetryModel t)
         {
-            t.HighFreq.LatAccel_ST = GetSdkValue<float>(d, "LatAccel_ST") ?? 0f;
-            t.HighFreq.LongAccel_ST = GetSdkValue<float>(d, "LongAccel_ST") ?? 0f;
+            t.HighFreq.LatAccel_ST = Pos(d, "LatAccel_ST");
+            t.HighFreq.LongAccel_ST = Pos(d, "LongAccel_ST");
         }
 
         private void PopulateDamageExtraData(IRacingSdkData d, TelemetryModel t)
         {
-            t.Damage.PlayerCarWeightPenalty = GetSdkValue<float>(d, "PlayerCarWeightPenalty") ?? 0f;
-            t.Damage.PlayerCarPowerAdjust = GetSdkValue<float>(d, "PlayerCarPowerAdjust") ?? 0f;
-            t.Damage.PlayerCarTowTime = GetSdkValue<float>(d, "PlayerCarTowTime") ?? 0f;
+            t.Damage.PlayerCarWeightPenalty = Pos(d, "PlayerCarWeightPenalty");
+            t.Damage.PlayerCarPowerAdjust = Pos(d, "PlayerCarPowerAdjust");
+            t.Damage.PlayerCarTowTime = Pos(d, "PlayerCarTowTime");
         }
     }
 }

--- a/backend/Services/IRacingTelemetryService.Calculations.cs
+++ b/backend/Services/IRacingTelemetryService.Calculations.cs
@@ -50,8 +50,7 @@ namespace SuperBackendNR85IA.Services
                     : 0f;
                 if (t.TotalLaps > 0)
                 {
-                    t.LapsRemainingRace = t.TotalLaps - t.Lap;
-                    if (t.LapsRemainingRace < 0) t.LapsRemainingRace = 0;
+                    t.LapsRemainingRace = Utilities.DataValidator.EnsureNonNegative(t.TotalLaps - t.Lap);
                 }
                 else
                 {

--- a/backend/Services/IRacingTelemetryService.Data.cs
+++ b/backend/Services/IRacingTelemetryService.Data.cs
@@ -328,6 +328,7 @@ namespace SuperBackendNR85IA.Services
                 _log.LogWarning($"Negative SessionTime received: {rawSessionTime}");
                 rawSessionTime = 0.0;
             }
+            rawSessionTime = Utilities.DataValidator.EnsurePositive(rawSessionTime);
 
             if (_log.IsEnabled(LogLevel.Debug))
                 _log.LogDebug($"Raw SessionTime: {rawSessionTime}");
@@ -663,7 +664,8 @@ namespace SuperBackendNR85IA.Services
                 _cachedYamlData = _yamlParser.ParseSessionInfo(
                     t.SessionInfoYaml,
                     t.PlayerCarIdx,
-                    t.SessionNum
+                    t.SessionNum,
+                    t.Session.SessionUniqueID
                 );
                 LogYamlDump(t.SessionInfoYaml);
                 _lastYaml = t.SessionInfoYaml;

--- a/backend/Services/IRacingTelemetryService.DriverArrays.cs
+++ b/backend/Services/IRacingTelemetryService.DriverArrays.cs
@@ -12,33 +12,33 @@ namespace SuperBackendNR85IA.Services
         {
             if (drv == null || drv.Length == 0) return;
             int maxIdx = drv.Max(x => x.CarIdx);
-            void Resize<T>(ref T[] arr)
+            void SetValue<T>(ref T[] arr, int idx, T value)
             {
-                if (arr == null) arr = Array.Empty<T>();
-                if (arr.Length <= maxIdx)
-                    Array.Resize(ref arr, maxIdx + 1);
+                Utilities.DataValidator.EnsureArraySize(ref arr, Math.Max(maxIdx + 1, idx + 1));
+                arr[idx] = value;
             }
 
             foreach (var d in drv)
             {
-                var carNumbers = t.CarIdxCarNumbers;      Resize(ref carNumbers);      carNumbers[d.CarIdx] = d.CarNumber;      t.CarIdxCarNumbers = carNumbers;
-                var userNames = t.CarIdxUserNames;        Resize(ref userNames);       userNames[d.CarIdx] = d.UserName;        t.CarIdxUserNames = userNames;
-                var licStrings = t.CarIdxLicStrings;      Resize(ref licStrings);      licStrings[d.CarIdx] = d.LicString;      t.CarIdxLicStrings = licStrings;
-                var iratings = t.CarIdxIRatings;          Resize(ref iratings);        iratings[d.CarIdx] = d.IRating;          t.CarIdxIRatings = iratings;
-                var teamNames = t.CarIdxTeamNames;        Resize(ref teamNames);       teamNames[d.CarIdx] = d.TeamName;         t.CarIdxTeamNames = teamNames;
-                var classIds = t.CarIdxCarClassIds;       Resize(ref classIds);        classIds[d.CarIdx] = d.CarClassID;       t.CarIdxCarClassIds = classIds;
-                var classShort = t.CarIdxCarClassShortNames; Resize(ref classShort);   classShort[d.CarIdx] = d.CarClassShortName; t.CarIdxCarClassShortNames = classShort;
-                var estTimes = t.CarIdxCarClassEstLapTimes; Resize(ref estTimes);      estTimes[d.CarIdx] = d.CarClassEstLapTime; t.CarIdxCarClassEstLapTimes = estTimes;
-                var compounds = t.CarIdxTireCompounds;     Resize(ref compounds);       compounds[d.CarIdx] = d.TireCompound;     t.CarIdxTireCompounds = compounds;
+                SetValue(ref t.CarIdxCarNumbers, d.CarIdx, d.CarNumber);
+                SetValue(ref t.CarIdxUserNames, d.CarIdx, d.UserName);
+                SetValue(ref t.CarIdxLicStrings, d.CarIdx, d.LicString);
+                SetValue(ref t.CarIdxIRatings, d.CarIdx, d.IRating);
+                SetValue(ref t.CarIdxTeamNames, d.CarIdx, d.TeamName);
+                SetValue(ref t.CarIdxCarClassIds, d.CarIdx, d.CarClassID);
+                SetValue(ref t.CarIdxCarClassShortNames, d.CarIdx, d.CarClassShortName);
+                SetValue(ref t.CarIdxCarClassEstLapTimes, d.CarIdx, d.CarClassEstLapTime);
+                SetValue(ref t.CarIdxTireCompounds, d.CarIdx, d.TireCompound);
                 if (d.CarIdx == t.PlayerCarIdx)
                 {
                     t.TireCompound   = d.TireCompound;
                     t.Tyres.Compound = d.TireCompound;
                 }
-
-                var irDeltas = t.CarIdxIRatingDeltas;      Resize(ref irDeltas);        if (_irStart.Length <= d.CarIdx) Array.Resize(ref _irStart, d.CarIdx + 1);
-                if (_irStart[d.CarIdx] == 0) _irStart[d.CarIdx] = d.IRating;           irDeltas[d.CarIdx] = d.IRating - _irStart[d.CarIdx];
-                t.CarIdxIRatingDeltas = irDeltas;
+                if (_irStart.Length <= d.CarIdx)
+                    Array.Resize(ref _irStart, d.CarIdx + 1);
+                if (_irStart[d.CarIdx] == 0)
+                    _irStart[d.CarIdx] = d.IRating;
+                SetValue(ref t.CarIdxIRatingDeltas, d.CarIdx, d.IRating - _irStart[d.CarIdx]);
             }
         }
     }

--- a/backend/Services/IRacingTelemetryService.Persistence.cs
+++ b/backend/Services/IRacingTelemetryService.Persistence.cs
@@ -7,17 +7,19 @@ namespace SuperBackendNR85IA.Services
     {
         private async Task PersistCarTrackData(TelemetryModel t)
         {
-            if (!string.IsNullOrEmpty(_carPath) && !string.IsNullOrEmpty(_trackName))
+            if (string.IsNullOrEmpty(_carPath) || string.IsNullOrEmpty(_trackName))
+                return;
+
+            var data = new CarTrackData
             {
-                await _store.UpdateAsync(new CarTrackData
-                {
-                    CarPath = _carPath,
-                    TrackName = _trackName,
-                    ConsumoMedio = t.ConsumoMedio,
-                    ConsumoUltimaVolta = _consumoUltimaVolta,
-                    FuelCapacity = t.FuelCapacity
-                });
-            }
+                CarPath = _carPath,
+                TrackName = _trackName,
+                ConsumoMedio = Utilities.DataValidator.EnsurePositive(t.ConsumoMedio),
+                ConsumoUltimaVolta = Utilities.DataValidator.EnsurePositive(_consumoUltimaVolta),
+                FuelCapacity = Utilities.DataValidator.EnsurePositive(t.FuelCapacity)
+            };
+
+            await _store.UpdateAsync(data);
         }
     }
 }

--- a/backend/Services/IRacingTelemetryService.Snapshot.cs
+++ b/backend/Services/IRacingTelemetryService.Snapshot.cs
@@ -15,11 +15,13 @@ namespace SuperBackendNR85IA.Services
                 float coldL, float coldM, float coldR,
                 float tread, float startTread)
             {
+                static float Avg(float a, float b, float c) => (a + b + c) / 3f;
+
                 return new TireData
                 {
-                    CurrentPressure = currentPress,
-                    LastHotPressure = lastHotPress,
-                    ColdPressure = coldPress,
+                    CurrentPressure = Utilities.DataValidator.EnsurePositive(currentPress),
+                    LastHotPressure = Utilities.DataValidator.EnsurePositive(lastHotPress),
+                    ColdPressure = Utilities.DataValidator.EnsurePositive(coldPress),
                     CurrentTempInternal = tempL,
                     CurrentTempMiddle = tempM,
                     CurrentTempExternal = tempR,
@@ -29,11 +31,11 @@ namespace SuperBackendNR85IA.Services
                     ColdTempInternal = coldL,
                     ColdTempMiddle = coldM,
                     ColdTempExternal = coldR,
-                    CoreTemp = (tempL + tempM + tempR) / 3f,
-                    LastHotTemp = (lastHotL + lastHotM + lastHotR) / 3f,
-                    ColdTemp = (coldL + coldM + coldR) / 3f,
+                    CoreTemp = Avg(tempL, tempM, tempR),
+                    LastHotTemp = Avg(lastHotL, lastHotM, lastHotR),
+                    ColdTemp = Avg(coldL, coldM, coldR),
                     Wear = startTread > 0f ? 1f - tread / startTread : 0f,
-                    TreadRemaining = tread,
+                    TreadRemaining = Utilities.DataValidator.EnsurePositive(tread),
                     SlipAngle = 0f,
                     SlipRatio = 0f,
                     Load = 0f,
@@ -78,8 +80,8 @@ namespace SuperBackendNR85IA.Services
                 FrontRightTire = fr,
                 RearLeftTire = rl,
                 RearRightTire = rr,
-                Speed = t.Speed,
-                Rpm = t.Rpm,
+                Speed = Utilities.DataValidator.EnsurePositive(t.Speed),
+                Rpm = Utilities.DataValidator.EnsurePositive(t.Rpm),
                 VerticalAcceleration = t.VertAccel,
                 LateralAcceleration = t.LatAccel,
                 LongitudinalAcceleration = t.LonAccel,

--- a/backend/Utilities/DataValidator.cs
+++ b/backend/Utilities/DataValidator.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace SuperBackendNR85IA.Utilities
+{
+    public static class DataValidator
+    {
+        public static float EnsurePositive(float value)
+        {
+            return float.IsNaN(value) || float.IsInfinity(value) || value < 0f ? 0f : value;
+        }
+
+        public static double EnsurePositive(double value)
+        {
+            return double.IsNaN(value) || double.IsInfinity(value) || value < 0.0 ? 0.0 : value;
+        }
+
+        public static int EnsureNonNegative(int value)
+        {
+            return value < 0 ? 0 : value;
+        }
+
+        public static long EnsureNonNegative(long value)
+        {
+            return value < 0 ? 0 : value;
+        }
+
+        public static void EnsureArraySize<T>(ref T[] array, int size)
+        {
+            if (array == null)
+                array = new T[size];
+            else if (array.Length < size)
+                Array.Resize(ref array, size);
+        }
+    }
+}

--- a/backend/Utilities/PerformanceMonitor.cs
+++ b/backend/Utilities/PerformanceMonitor.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace SuperBackendNR85IA.Utilities
+{
+    public sealed class PerformanceMonitor : IDisposable
+    {
+        private readonly ILogger _logger;
+        private readonly string _operation;
+        private readonly Stopwatch _sw = Stopwatch.StartNew();
+
+        public PerformanceMonitor(ILogger logger, string operation)
+        {
+            _logger = logger;
+            _operation = operation;
+        }
+
+        public void Dispose()
+        {
+            _sw.Stop();
+            _logger.LogDebug($"{_operation} took {_sw.ElapsedMilliseconds} ms");
+        }
+    }
+}

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,32 @@
+# Refactoring Progress
+
+- [x] backend/Program.cs
+- [x] backend/Repositories/ICarTrackRepository.cs
+- [x] backend/Services/CarTrackDataStore.cs
+- [x] backend/Services/IRacingTelemetryService.cs
+- [x] backend/Services/IRacingTelemetryService.Data.cs
+- [x] backend/Services/IRacingTelemetryService.Calculations.cs
+- [x] backend/Services/SessionYamlParser.cs
+- [x] backend/Utilities/DataValidator.cs
+- [x] backend/Services/TelemetryBroadcaster.cs
+- [x] backend/Services/IRacingTelemetryService.DriverArrays.cs
+- [x] backend/Services/IRacingTelemetryService.AllExtras.cs
+- [x] backend/Services/IRacingTelemetryService.Persistence.cs
+- [x] backend/Services/IRacingTelemetryService.Snapshot.cs
+- [x] backend/Services/EnumTranslations.cs
+- [ ] backend/Models/DamageData.cs
+- [ ] backend/Models/DriverInfo.cs
+- [ ] backend/Models/FrontendDataPayload.cs
+- [ ] backend/Models/Proximity.cs
+- [ ] backend/Models/ResultPosition.cs
+- [ ] backend/Models/SessionData.cs
+- [ ] backend/Models/SessionDetailFromYaml.cs
+- [ ] backend/Models/SessionInfo.cs
+- [ ] backend/Models/SectorInfo.cs
+- [ ] backend/Models/TelemetryCalculations.cs
+- [ ] backend/Models/TelemetryCalculationsOverlay.cs
+- [ ] backend/Models/TelemetryExtras.Models.cs
+- [ ] backend/Models/TelemetryModel.cs
+- [ ] backend/Models/TyreData.cs
+- [ ] backend/Models/VehicleData.cs
+- [ ] backend/Models/WeekendInfo.cs


### PR DESCRIPTION
## Summary
- simplify translation lookups with static dictionaries
- centralize array resizing in `DataValidator`
- use the helper in `PopulateDriverArrays`
- mark progress in `todo.md`
- sanitize extra data and snapshots with new helpers
- validate persisted car/track data

## Testing
- `dotnet build backend/SuperBackendNR85IA.csproj -nologo` *(fails: command not found)*
- `npm test --prefix telemetry-frontend`

------
https://chatgpt.com/codex/tasks/task_e_6852acb325648330b06903e44f9cdb23