### PR TITLE
Resolve CarTrackDataStore logger warning

### DIFF
--- a/backend/Services/CarTrackDataStore.cs
+++ b/backend/Services/CarTrackDataStore.cs
@@ -21,7 +21,6 @@ namespace SuperBackendNR85IA.Services
     {
         // Caminho para armazenamento do JSON contendo dados por carro/pista
         private readonly string _filePath;
-        private readonly ILogger<CarTrackDataStore> _logger;
         private readonly object _lock = new();
         private readonly ILogger<CarTrackDataStore> _log;
         private Dictionary<string, CarTrackData> _data = new();


### PR DESCRIPTION
## Summary
- remove unused `_logger` field in `CarTrackDataStore`

## Testing
- `npm test` *(fails: No tests configured)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854241ffe208330a4c68c8a13fd1d97