### PR TITLE
Fix negative fuel recommendation

### DIFF
--- a/backend/Models/TelemetryCalculations.cs
+++ b/backend/Models/TelemetryCalculations.cs
@@ -265,8 +265,10 @@ namespace SuperBackendNR85IA.Calculations
                     consumoParaCalculo),
                 nameof(model.NecessarioFim));
 
-            float faltante = model.NecessarioFim - model.FuelLevel;
-            model.RecomendacaoAbastecimento = ValidateFloat(faltante, nameof(model.RecomendacaoAbastecimento));
+            float faltante = Math.Max(0f, model.NecessarioFim - model.FuelLevel);
+            model.RecomendacaoAbastecimento = ValidateFloat(
+                faltante,
+                nameof(model.RecomendacaoAbastecimento));
         }
 
         public static void UpdateSectorData(ref TelemetryModel model)


### PR DESCRIPTION
## Summary
- avoid negative values when calculating `RecomendacaoAbastecimento`

## Testing
- `dotnet build backend/SuperBackendNR85IA.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685426a1ad708330b43f66b717a06123