### PR TITLE
Expand Telemetry fields

### DIFF
--- a/backend/Models/TelemetryAdditionalFields.cs
+++ b/backend/Models/TelemetryAdditionalFields.cs
@@ -1,0 +1,59 @@
+using System;
+
+namespace SuperBackendNR85IA.Models
+{
+    // Additional telemetry fields not covered elsewhere
+    public partial record VehicleData
+    {
+        public bool IsOnTrack { get; set; }
+        public bool IsInGarage { get; set; }
+        public float VelocityX { get; set; }
+        public float VelocityY { get; set; }
+        public float VelocityZ { get; set; }
+        public float YawNorth { get; set; }
+    }
+
+    public partial record SessionData
+    {
+        public int DisplayUnits { get; set; }
+        public bool DriverMarker { get; set; }
+    }
+
+    public record ReplayData
+    {
+        public int PlaySpeed { get; set; }
+        public bool PlaySlowMotion { get; set; }
+        public double SessionTime { get; set; }
+        public int SessionNum { get; set; }
+    }
+
+    public record DcuData
+    {
+        public int DcLapStatus { get; set; }
+        public int DcDriversSoFar { get; set; }
+    }
+
+    public partial class TelemetryModel
+    {
+        public ReplayData Replay { get; set; } = new ReplayData();
+        public DcuData Dcu { get; set; } = new DcuData();
+
+        public bool IsOnTrack { get => Vehicle.IsOnTrack; set => Vehicle.IsOnTrack = value; }
+        public bool IsInGarage { get => Vehicle.IsInGarage; set => Vehicle.IsInGarage = value; }
+        public float VelocityX { get => Vehicle.VelocityX; set => Vehicle.VelocityX = value; }
+        public float VelocityY { get => Vehicle.VelocityY; set => Vehicle.VelocityY = value; }
+        public float VelocityZ { get => Vehicle.VelocityZ; set => Vehicle.VelocityZ = value; }
+        public float YawNorth { get => Vehicle.YawNorth; set => Vehicle.YawNorth = value; }
+
+        public int DisplayUnits { get => Session.DisplayUnits; set => Session.DisplayUnits = value; }
+        public bool DriverMarker { get => Session.DriverMarker; set => Session.DriverMarker = value; }
+
+        public int ReplayPlaySpeed { get => Replay.PlaySpeed; set => Replay.PlaySpeed = value; }
+        public bool ReplayPlaySlowMotion { get => Replay.PlaySlowMotion; set => Replay.PlaySlowMotion = value; }
+        public double ReplaySessionTime { get => Replay.SessionTime; set => Replay.SessionTime = value; }
+        public int ReplaySessionNum { get => Replay.SessionNum; set => Replay.SessionNum = value; }
+
+        public int DcLapStatus { get => Dcu.DcLapStatus; set => Dcu.DcLapStatus = value; }
+        public int DcDriversSoFar { get => Dcu.DcDriversSoFar; set => Dcu.DcDriversSoFar = value; }
+    }
+}

--- a/backend/Services/IRacingTelemetryService.AllExtras.cs
+++ b/backend/Services/IRacingTelemetryService.AllExtras.cs
@@ -37,6 +37,8 @@ namespace SuperBackendNR85IA.Services
             PopulateSystemPerformanceData(d, t);
             PopulateHighFreqData(d, t);
             PopulateDamageExtraData(d, t);
+            PopulateReplayData(d, t);
+            PopulateDcuData(d, t);
         }
 
         private void PopulateAdvancedVehicleData(IRacingSdkData d, TelemetryModel t)
@@ -94,6 +96,8 @@ namespace SuperBackendNR85IA.Services
             t.Session.SessionUniqueID = NonNegLong(d, "SessionUniqueID");
             t.Session.SessionTick = NonNeg(d, "SessionTick");
             t.Session.SessionTimeTotal = Pos(d, "SessionTimeTotal");
+            t.Session.DisplayUnits = (GetSdkValue<bool>(d, "DisplayUnits") ?? false) ? 1 : 0;
+            t.Session.DriverMarker = GetSdkValue<bool>(d, "DriverMarker") ?? false;
             t.Environment.WeatherDeclaredWet = GetSdkValue<bool>(d, "WeatherDeclaredWet") ?? false;
             t.Environment.SolarAltitude = Pos(d, "SolarAltitude");
             t.Environment.SolarAzimuth = Pos(d, "SolarAzimuth");
@@ -143,6 +147,20 @@ namespace SuperBackendNR85IA.Services
             t.Damage.PlayerCarWeightPenalty = Pos(d, "PlayerCarWeightPenalty");
             t.Damage.PlayerCarPowerAdjust = Pos(d, "PlayerCarPowerAdjust");
             t.Damage.PlayerCarTowTime = Pos(d, "PlayerCarTowTime");
+        }
+
+        private void PopulateReplayData(IRacingSdkData d, TelemetryModel t)
+        {
+            t.Replay.PlaySpeed = NonNeg(d, "ReplayPlaySpeed");
+            t.Replay.PlaySlowMotion = GetSdkValue<bool>(d, "ReplayPlaySlowMotion") ?? false;
+            t.Replay.SessionTime = GetSdkValue<double>(d, "ReplaySessionTime") ?? 0.0;
+            t.Replay.SessionNum = NonNeg(d, "ReplaySessionNum");
+        }
+
+        private void PopulateDcuData(IRacingSdkData d, TelemetryModel t)
+        {
+            t.Dcu.DcLapStatus = NonNeg(d, "dcLapStatus");
+            t.Dcu.DcDriversSoFar = NonNeg(d, "dcDriversSoFar");
         }
     }
 }

--- a/backend/Services/IRacingTelemetryService.Data.cs
+++ b/backend/Services/IRacingTelemetryService.Data.cs
@@ -162,6 +162,13 @@ namespace SuperBackendNR85IA.Services
             t.Powertrain.EnergyBatteryToMguKLap  = GetSdkValue<float>(d, "EnergyBatteryToMGU_KLap") ?? 0f;
             t.Powertrain.ManualBoost             = GetSdkValue<bool>(d, "ManualBoost") ?? false;
             t.Powertrain.ManualNoBoost           = GetSdkValue<bool>(d, "ManualNoBoost") ?? false;
+
+            t.Vehicle.IsOnTrack  = GetSdkValue<bool>(d, "IsOnTrack") ?? false;
+            t.Vehicle.IsInGarage = GetSdkValue<bool>(d, "IsInGarage") ?? false;
+            t.Vehicle.VelocityX  = GetSdkValue<float>(d, "VelocityX") ?? 0f;
+            t.Vehicle.VelocityY  = GetSdkValue<float>(d, "VelocityY") ?? 0f;
+            t.Vehicle.VelocityZ  = GetSdkValue<float>(d, "VelocityZ") ?? 0f;
+            t.Vehicle.YawNorth   = GetSdkValue<float>(d, "YawNorth") ?? 0f;
         }
 
         private void UpdateLapInfo(IRacingSdkData d, TelemetryModel t)


### PR DESCRIPTION
## Summary
- add structures for Replay and DCU data
- expose new fields like DisplayUnits and Velocity components
- populate the new data from SDK values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68545620bb948330b7d6056776ba584d