### PR TITLE
Fix partial declaration error

### DIFF
--- a/backend/Models/SessionData.cs
+++ b/backend/Models/SessionData.cs
@@ -1,6 +1,6 @@
 namespace SuperBackendNR85IA.Models
 {
-    public record SessionData
+    public partial record SessionData
     {
         public int SessionNum { get; set; }
         public double SessionTime { get; set; }


### PR DESCRIPTION
## Summary
- mark `SessionData` as partial to match other declarations

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854588445ac8330a533ef7da491cfd0