### PR TITLE
Expose raw SDK telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Every WebSocket payload includes the raw `sessionInfoYaml` string from iRacing *
 - `yamlSessionInfo` – data for the current session, including lap counts
 - `yamlSectorInfo` – sector configuration and best sector times
 - `yamlDrivers` – an array with basic info on all drivers
+- `sdkRaw` – dictionary with every telemetry variable captured from the iRacing SDK
 
 A sample payload is available in `ws/messages/overlay_message.json` and the latest YAML dump is written to `yamls/input_current.yaml` whenever the backend updates.
 

--- a/backend/Models/TelemetryModel.cs
+++ b/backend/Models/TelemetryModel.cs
@@ -370,6 +370,11 @@ namespace SuperBackendNR85IA.Models
         public string SessionInfoYaml { get; set; } = string.Empty;
         public List<ResultPosition> Results { get; set; } = new();
 
+        // Raw values captured directly from the iRacing SDK. Keys follow the
+        // original variable names as provided by the SDK and values can be
+        // scalars or arrays depending on the variable type.
+        public Dictionary<string, object?> SdkRaw { get; set; } = new();
+
         public TyreStatus LfTempStatus { get; set; } = new(TyreHelpers.TempStatus.Cold, TyreHelpers.TempStatus.Cold, TyreHelpers.TempStatus.Cold);
         public TyreStatus RfTempStatus { get; set; } = new(TyreHelpers.TempStatus.Cold, TyreHelpers.TempStatus.Cold, TyreHelpers.TempStatus.Cold);
         public TyreStatus LrTempStatus { get; set; } = new(TyreHelpers.TempStatus.Cold, TyreHelpers.TempStatus.Cold, TyreHelpers.TempStatus.Cold);

--- a/backend/Services/IRacingTelemetryService.Data.cs
+++ b/backend/Services/IRacingTelemetryService.Data.cs
@@ -661,6 +661,35 @@ namespace SuperBackendNR85IA.Services
             t.Damage.ChassisDamage = t.Damage.SuspensionDamage;
         }
 
+        private void CaptureSdkRawValues(IRacingSdkData d, TelemetryModel t)
+        {
+            var raw = new Dictionary<string, object?>();
+            foreach (var (name, datum) in d.TelemetryDataProperties)
+            {
+                try
+                {
+                    var value = d.GetValue(datum);
+                    if (value is char[] chars)
+                        raw[name] = new string(chars).TrimEnd('\0');
+                    else if (value is Array arr)
+                    {
+                        var list = new List<object?>();
+                        foreach (var item in arr) list.Add(item);
+                        raw[name] = list.ToArray();
+                    }
+                    else
+                    {
+                        raw[name] = value;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _log.LogDebug(ex, $"Falha ao ler variável {name}");
+                }
+            }
+            t.SdkRaw = raw;
+        }
+
         private async Task ApplyYamlData(IRacingSdkData d, TelemetryModel t)
         {
             t.SessionInfoYaml = _sdk.Data?.SessionInfoYaml ?? string.Empty;

--- a/backend/Services/IRacingTelemetryService.cs
+++ b/backend/Services/IRacingTelemetryService.cs
@@ -190,6 +190,7 @@ namespace SuperBackendNR85IA.Services
             ComputeRelativeDistances(d, t);
             PopulateSessionInfo(d, t);
             PopulateTyres(d, t);
+            CaptureSdkRawValues(d, t);
             if (_log.IsEnabled(LogLevel.Debug))
             {
                 _log.LogDebug(

--- a/ws/messages/overlay_message.json
+++ b/ws/messages/overlay_message.json
@@ -129,5 +129,10 @@
       "carIdx": 1,
       "userName": "Driver Two"
     }
-  ]
+  ],
+  "sdkRaw": {
+    "RPM": 8500,
+    "Speed": 100,
+    "Gear": 4
+  }
 }


### PR DESCRIPTION
## Summary
- capture all telemetry fields from iRacing
- expose them through new `SdkRaw` dictionary property
- include raw values in sample overlay payload
- document new property in README

## Testing
- `jq . ws/messages/overlay_message.json`

------
https://chatgpt.com/codex/tasks/task_e_68545864f35c83308ba3f3b6fab40bd0