### PR TITLE
Remove heavy SdkRaw data from WS payloads

### DIFF
--- a/backend/Models/TelemetryModel.cs
+++ b/backend/Models/TelemetryModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using SuperBackendNR85IA.Calculations;
 
 namespace SuperBackendNR85IA.Models
@@ -373,6 +374,7 @@ namespace SuperBackendNR85IA.Models
         // Raw values captured directly from the iRacing SDK. Keys follow the
         // original variable names as provided by the SDK and values can be
         // scalars or arrays depending on the variable type.
+        [JsonIgnore]
         public Dictionary<string, object?> SdkRaw { get; set; } = new();
 
         public TyreStatus LfTempStatus { get; set; } = new(TyreHelpers.TempStatus.Cold, TyreHelpers.TempStatus.Cold, TyreHelpers.TempStatus.Cold);

--- a/backend/Services/IRacingTelemetryService.cs
+++ b/backend/Services/IRacingTelemetryService.cs
@@ -88,7 +88,9 @@ namespace SuperBackendNR85IA.Services
         private readonly HashSet<string> _missingVarWarned = new();
 
         private static readonly PropertyInfo[] _telemetryProps =
-            typeof(TelemetryModel).GetProperties();
+            typeof(TelemetryModel).GetProperties()
+                .Where(p => p.Name != nameof(TelemetryModel.SdkRaw))
+                .ToArray();
         private static readonly string[] _telemetryPropNames = _telemetryProps
             .Select(p => char.ToLowerInvariant(p.Name[0]) + p.Name.Substring(1))
             .ToArray();


### PR DESCRIPTION
## Summary
- exclude the `SdkRaw` property when building payloads
- mark `TelemetryModel.SdkRaw` with `JsonIgnore`

## Testing
- `dotnet build backend/SuperBackendNR85IA.csproj -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68547aff8d6483308dc1cc4ca94cfdca