### PR TITLE
Fix code pages encoding error

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -3,8 +3,12 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System.Text.Json;
+using System.Text; // for Encoding
 using SuperBackendNR85IA.Services;
 using SuperBackendNR85IA.Repositories;
+
+// Enable code pages encoding for IRSDKSharper (e.g., Windows-1252)
+Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 
 var builder = WebApplication.CreateBuilder(args);
 


### PR DESCRIPTION
## Summary
- enable legacy code pages to prevent `No data is available for encoding 1252` error in backend

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68579acb6c28833083cdb2139119af50