### PR TITLE
Fix overlay Babel links

### DIFF
--- a/telemetry-frontend/public/overlays/overlay-classificacao.html
+++ b/telemetry-frontend/public/overlays/overlay-classificacao.html
@@ -7,7 +7,7 @@
   <script src="https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/dist/js-yaml.min.js">
   <script crossorigin src="https://unpkg.com/react/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom/umd/react-dom.development.js"></script>
-  <script src="https://unpkg.com//standalone/babel.min.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   <script src="../telemetry-context.js"></script></script>
   <style>
     html,body{margin:0;padding:0;height:100%;font-family:'Poppins',sans-serif;background:rgba(15,23,42,0.9);color:#e2e8f0;overflow:hidden;font-size:0.85rem;;transform:translateZ(0);will-change:transform}

--- a/telemetry-frontend/public/overlays/overlay-delta.html
+++ b/telemetry-frontend/public/overlays/overlay-delta.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"/>
   <script crossorigin src="https://unpkg.com/react/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom/umd/react-dom.development.js"></script>
-  <script src="https://unpkg.com//standalone/babel.min.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   <script src="../telemetry-context.js"></script>
   <style>
     /* Estilos globais */

--- a/telemetry-frontend/public/overlays/overlay-relative.html
+++ b/telemetry-frontend/public/overlays/overlay-relative.html
@@ -11,7 +11,7 @@
     <script src="https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/dist/js-yaml.min.js">
     <script crossorigin src="https://unpkg.com/react/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom/umd/react-dom.development.js"></script>
-    <script src="https://unpkg.com//standalone/babel.min.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
     <script src="../telemetry-context.js"></script></script>
     <style>
         /* Estilos Globais da Overlay */

--- a/telemetry-frontend/public/overlays/overlay-sessao.html
+++ b/telemetry-frontend/public/overlays/overlay-sessao.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"/>
   <script crossorigin src="https://unpkg.com/react/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom/umd/react-dom.development.js"></script>
-  <script src="https://unpkg.com//standalone/babel.min.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   <script src="../telemetry-context.js"></script>
   <style>
     body, html {

--- a/telemetry-frontend/public/overlays/overlay-tanque.html
+++ b/telemetry-frontend/public/overlays/overlay-tanque.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"/>
   <script crossorigin src="https://unpkg.com/react/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom/umd/react-dom.development.js"></script>
-  <script src="https://unpkg.com//standalone/babel.min.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   <script src="../telemetry-context.js"></script>
   <style>
     /* Estilos globais para o corpo */

--- a/telemetry-frontend/public/overlays/overlay-tiresandbrakes.html
+++ b/telemetry-frontend/public/overlays/overlay-tiresandbrakes.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"/>
   <script crossorigin src="https://unpkg.com/react/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom/umd/react-dom.development.js"></script>
-  <script src="https://unpkg.com//standalone/babel.min.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   <script src="../telemetry-context.js"></script>
   <style>
     /* Estilos globais para o corpo */

--- a/telemetry-frontend/public/overlays/overlay-tiresgarage.html
+++ b/telemetry-frontend/public/overlays/overlay-tiresgarage.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"/>
   <script crossorigin src="https://unpkg.com/react/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom/umd/react-dom.development.js"></script>
-  <script src="https://unpkg.com//standalone/babel.min.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   <script src="../telemetry-context.js"></script>
   <style>
     /* Base body styles for the overlay background and font */


### PR DESCRIPTION
## Summary
- fix broken Babel standalone URLs for several overlays

## Testing
- `npm test`
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685834f2a49483309599d6b087e3ad14