### PR TITLE
Fix overlay WebSocket host for remote connections

### DIFF
--- a/telemetry-frontend/public/telemetry-context.js
+++ b/telemetry-frontend/public/telemetry-context.js
@@ -6,7 +6,12 @@
     const [telemetry, setTelemetry] = useState({});
 
     useEffect(() => {
-      const url = window.OVERLAY_WS_URL || 'ws://localhost:5221/ws';
+      function overlayHost() {
+        const host = window.location.hostname;
+        return host && host.length > 0 ? host : 'localhost';
+      }
+
+      const url = window.OVERLAY_WS_URL || `ws://${overlayHost()}:5221/ws`;
       let socket;
       let reconnect;
 

--- a/telemetry-frontend/src/TelemetryContext.jsx
+++ b/telemetry-frontend/src/TelemetryContext.jsx
@@ -6,7 +6,12 @@ export function TelemetryProvider({ children }) {
   const [telemetry, setTelemetry] = useState({});
 
   useEffect(() => {
-    const url = window.OVERLAY_WS_URL || 'ws://localhost:5221/ws';
+    function overlayHost() {
+      const host = window.location.hostname;
+      return host && host.length > 0 ? host : 'localhost';
+    }
+
+    const url = window.OVERLAY_WS_URL || `ws://${overlayHost()}:5221/ws`;
     let socket;
     let reconnect;
 


### PR DESCRIPTION
## Summary
- ensure React TelemetryProvider resolves host from `window.location`
- update compiled public script

## Testing
- `npm test` *(fails: No tests configured)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685837037f508330b5a3ab5b71c4eb76